### PR TITLE
Add options to disable parts of remote props

### DIFF
--- a/NewHorizons/Builder/Props/RemoteBuilder.cs
+++ b/NewHorizons/Builder/Props/RemoteBuilder.cs
@@ -208,6 +208,8 @@ namespace NewHorizons.Builder.Props
                 component._nomaiTexts[i] = wallText;
             }
 
+            if (info.disableWall) whiteboard.FindChild("Props_NOM_Whiteboard_Shared").SetActive(false);
+
             whiteboard.SetActive(true);
         }
 
@@ -250,6 +252,14 @@ namespace NewHorizons.Builder.Props
             component._id = id;
             component._visualSector = sector;
             component._dataPointID = info.reveals;
+
+            if (info.disableStructure)
+            {
+                platform.FindChild("Structure_NOM_RemoteViewer").SetActive(false);
+                platform.FindChild("RemoteViewer_FadeGeo").SetActive(false);
+            }
+
+            if (info.disablePool) platform.FindChild("RemoteViewer_Pool").SetActive(false);
 
             platform.SetActive(true);
         }

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -891,6 +891,11 @@ namespace NewHorizons.External.Modules
                 /// </summary>
                 public string rename;
 
+                /// <summary>
+                /// Disable the wall, leaving only the pedestal and text.
+                /// </summary>
+                public bool disableWall;
+
                 [JsonObject]
                 public class SharedNomaiTextInfo
                 {
@@ -953,6 +958,16 @@ namespace NewHorizons.External.Modules
                 /// A ship log fact to reveal when the platform is connected to.
                 /// </summary>
                 [DefaultValue("")] public string reveals = "";
+
+                /// <summary>
+                /// Disable the structure, leaving only the pedestal.
+                /// </summary>
+                public bool disableStructure;
+
+                /// <summary>
+                /// Disable the pool that rises when you place a stone.
+                /// </summary>
+                public bool disablePool;
             }
 
             [JsonObject]

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1973,6 +1973,10 @@
         "rename": {
           "type": "string",
           "description": "An optional rename of this object"
+        },
+        "disableWall": {
+          "type": "boolean",
+          "description": "Disable the wall, leaving only the pedestal and text."
         }
       }
     },
@@ -2035,6 +2039,14 @@
           "type": "string",
           "description": "A ship log fact to reveal when the platform is connected to.",
           "default": ""
+        },
+        "disableStructure": {
+          "type": "boolean",
+          "description": "Disable the structure, leaving only the pedestal."
+        },
+        "disablePool": {
+          "type": "boolean",
+          "description": "Disable the pool that rises when you place a stone."
         }
       }
     },


### PR DESCRIPTION
You can now disable individual parts of projection platforms and shared whiteboards.

For whiteboards you can disable walls
![image](https://user-images.githubusercontent.com/34462599/186278621-57286a6e-c8fb-4fa4-b46c-c987575e192d.png)
![image](https://user-images.githubusercontent.com/34462599/186278657-4844ea66-faa9-4ac7-a321-375989037b99.png)

For platforms you can disable the floor structure and the pool that rises when you place a stone.
![image](https://user-images.githubusercontent.com/34462599/186278952-d046cb91-e1de-4f34-b316-6e917912df7c.png)
![image](https://user-images.githubusercontent.com/34462599/186278781-ef64f158-e8ce-4584-b9d6-2b96f8183985.png)