### PR TITLE
Make dimensions cull inner nodes

### DIFF
--- a/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
+++ b/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
@@ -192,8 +192,12 @@ namespace NewHorizons.Builder.Body
             cloak.GetComponent<Renderer>().enabled = true;
 
             // Cull stuff
-            var cullController = go.AddComponent<BrambleSectorController>();
-            cullController.SetSector(sector);
+            // Do next update so other nodes can be built first
+            Delay.FireOnNextUpdate(() =>
+            {
+                var cullController = go.AddComponent<BrambleSectorController>();
+                cullController.SetSector(sector);
+            });
 
             // finalize
             atmo.SetActive(true);


### PR DESCRIPTION
I think sometimes nodes are built after BrambleSectorController registers renderers, meaning some nodes don't get hidden. This PR attempts to fix that.