### PR TITLE
cull/collision/lights groups

### DIFF
--- a/NewHorizons/Builder/General/GroupBuilder.cs
+++ b/NewHorizons/Builder/General/GroupBuilder.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using Logger = NewHorizons.Utility.Logger;
+
+namespace NewHorizons.Builder.General;
+
+public static class GroupBuilder
+{
+    /// <summary>
+    /// puts groups on objects.
+    /// run this before the gameobject is active.
+    /// </summary>
+    public static void Make(GameObject go, Sector sector)
+    {
+        Logger.LogVerbose($"putting groups on {go} (linked to {sector})");
+        if (!sector)
+        {
+            Logger.LogWarning("tried to put groups on a null sector");
+            return;
+        }
+        if (go.activeInHierarchy)
+        {
+            Logger.LogWarning("tried to put groups on an active gameobject");
+            return;
+        }
+
+        go.GetAddComponent<SectorCullGroup>()._sector = sector;
+        go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
+        go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
+    }
+}

--- a/NewHorizons/Builder/General/GroupBuilder.cs
+++ b/NewHorizons/Builder/General/GroupBuilder.cs
@@ -11,15 +11,14 @@ public static class GroupBuilder
     /// </summary>
     public static void Make(GameObject go, Sector sector)
     {
-        Logger.LogVerbose($"putting groups on {go} (linked to {sector})");
         if (!sector)
         {
-            Logger.LogWarning("tried to put groups on a null sector");
+            Logger.LogWarning($"tried to put groups on {go.name} when sector is null");
             return;
         }
         if (go.activeInHierarchy)
         {
-            Logger.LogWarning("tried to put groups on an active gameobject");
+            Logger.LogWarning($"tried to put groups on an active gameobject {go.name}");
             return;
         }
 

--- a/NewHorizons/Builder/General/GroupsBuilder.cs
+++ b/NewHorizons/Builder/General/GroupsBuilder.cs
@@ -1,31 +1,29 @@
 ﻿using UnityEngine;
 using Logger = NewHorizons.Utility.Logger;
 
-namespace NewHorizons.Builder.General
-{
-    public static class GroupsBuilder
-    {
-        /// <summary>
-        /// puts groups on an object, activated by sector.
-        /// run this before the gameobject is active.
-        /// </summary>
-        public static void Make(GameObject go, Sector sector)
-        {
-            if (!sector)
-            {
-                Logger.LogWarning($"tried to put groups on {go.name} when sector is null");
-                return;
-            }
-            if (go.activeInHierarchy)
-            {
-                Logger.LogWarning($"tried to put groups on an active gameobject {go.name}");
-                return;
-            }
-            Logger.LogVerbose($"putting groups on {go.name}");
+namespace NewHorizons.Builder.General;
 
-            go.GetAddComponent<SectorCullGroup>()._sector = sector;
-            go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
-            go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
+public static class GroupsBuilder
+{
+    /// <summary>
+    /// puts groups on an object, activated by sector.
+    /// run this before the gameobject is active.
+    /// </summary>
+    public static void Make(GameObject go, Sector sector)
+    {
+        if (!sector)
+        {
+            Logger.LogWarning($"tried to put groups on {go.name} when sector is null");
+            return;
         }
+        if (go.activeInHierarchy)
+        {
+            Logger.LogWarning($"tried to put groups on an active gameobject {go.name}");
+            return;
+        }
+
+        go.GetAddComponent<SectorCullGroup>()._sector = sector;
+        go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
+        go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
     }
 }

--- a/NewHorizons/Builder/General/GroupsBuilder.cs
+++ b/NewHorizons/Builder/General/GroupsBuilder.cs
@@ -3,10 +3,10 @@ using Logger = NewHorizons.Utility.Logger;
 
 namespace NewHorizons.Builder.General;
 
-public static class GroupBuilder
+public static class GroupsBuilder
 {
     /// <summary>
-    /// puts groups on objects.
+    /// puts groups on an object, activated by sector.
     /// run this before the gameobject is active.
     /// </summary>
     public static void Make(GameObject go, Sector sector)

--- a/NewHorizons/Builder/General/GroupsBuilder.cs
+++ b/NewHorizons/Builder/General/GroupsBuilder.cs
@@ -1,29 +1,31 @@
 ﻿using UnityEngine;
 using Logger = NewHorizons.Utility.Logger;
 
-namespace NewHorizons.Builder.General;
-
-public static class GroupsBuilder
+namespace NewHorizons.Builder.General
 {
-    /// <summary>
-    /// puts groups on an object, activated by sector.
-    /// run this before the gameobject is active.
-    /// </summary>
-    public static void Make(GameObject go, Sector sector)
+    public static class GroupsBuilder
     {
-        if (!sector)
+        /// <summary>
+        /// puts groups on an object, activated by sector.
+        /// run this before the gameobject is active.
+        /// </summary>
+        public static void Make(GameObject go, Sector sector)
         {
-            Logger.LogWarning($"tried to put groups on {go.name} when sector is null");
-            return;
-        }
-        if (go.activeInHierarchy)
-        {
-            Logger.LogWarning($"tried to put groups on an active gameobject {go.name}");
-            return;
-        }
+            if (!sector)
+            {
+                Logger.LogWarning($"tried to put groups on {go.name} when sector is null");
+                return;
+            }
+            if (go.activeInHierarchy)
+            {
+                Logger.LogWarning($"tried to put groups on an active gameobject {go.name}");
+                return;
+            }
+            Logger.LogVerbose($"putting groups on {go.name}");
 
-        go.GetAddComponent<SectorCullGroup>()._sector = sector;
-        go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
-        go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
+            go.GetAddComponent<SectorCullGroup>()._sector = sector;
+            go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
+            go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
+        }
     }
 }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -101,7 +101,7 @@ namespace NewHorizons.Builder.Props
 
             prop.transform.localScale = detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale;
 
-            if (!detail.keepLoaded) GroupBuilder.Make(prop, sector);
+            if (!detail.keepLoaded) GroupsBuilder.Make(prop, sector);
             prop.SetActive(true);
 
             if (prop == null) return null;

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Builder.General;
 using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
 using NewHorizons.Handlers;
@@ -100,6 +101,7 @@ namespace NewHorizons.Builder.Props
 
             prop.transform.localScale = detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale;
 
+            if (!detail.keepLoaded) GroupBuilder.Make(prop, sector);
             prop.SetActive(true);
 
             if (prop == null) return null;

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -96,6 +96,7 @@ namespace NewHorizons.Builder.Props
                     {
                         position = point.normalized * height,
                         scale = propInfo.scale,
+                        keepLoaded = propInfo.keepLoaded,
                         alignToNormal = true
                     };
                     var prop = DetailBuilder.Make(go, sector, prefab, detailInfo);

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -139,6 +139,11 @@ namespace NewHorizons.External.Modules
             /// The highest height that these objects will be placed at (only relevant if there's a heightmap)
             /// </summary>
             public float? maxHeight;
+            
+            /// <summary>
+            /// Should this detail stay loaded even if you're outside the sector (good for very large props)
+            /// </summary>
+            public bool keepLoaded;
         }
 
         [JsonObject]


### PR DESCRIPTION
groups make things turn off when you're not in the sector. (cull = renderers, collision = colliders/shapes, lights = lights)
this pr makes nh add groups to anything using DetailBuilder.Make
this should improve performance, since things will only appear when you're close enough to them. it should also help with Jack's mod since he uses lots of cacti (ie volumes)

this pr also makes keepLoaded actually function (and adds the setting to scatter)