### PR TITLE
Fix dialog text not trimmed in translation table key

### DIFF
--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -211,7 +211,8 @@ namespace NewHorizons.Builder.Props
                 {
                     XmlNode pageData = (XmlNode)Page;
                     var text = pageData.InnerText;
-                    TranslationHandler.AddDialogue(text, name);
+                    // The text is trimmed in CharacterDialogueTree.LoadXml, so we also need to trim it for the key
+                    TranslationHandler.AddDialogue(text, true, name);
                 }
 
                 xmlText = xmlNode2.SelectNodes("DialogueOptionsList/DialogueOption/Text");
@@ -219,7 +220,8 @@ namespace NewHorizons.Builder.Props
                 {
                     XmlNode pageData = (XmlNode)Page;
                     var text = pageData.InnerText;
-                    TranslationHandler.AddDialogue(text, characterName, name);
+                    // The text is trimmed in DialogueText constructor (_listTextBlocks), so we also need to trim it for the key
+                    TranslationHandler.AddDialogue(text, true, characterName, name);
                 }
             }
         }

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -207,19 +207,19 @@ namespace NewHorizons.Builder.Props
                 var name = xmlNode2.SelectSingleNode("Name").InnerText;
 
                 XmlNodeList xmlText = xmlNode2.SelectNodes("Dialogue/Page");
-                foreach (object Page in xmlText)
+                foreach (object page in xmlText)
                 {
-                    XmlNode pageData = (XmlNode)Page;
+                    XmlNode pageData = (XmlNode)page;
                     var text = pageData.InnerText;
                     // The text is trimmed in DialogueText constructor (_listTextBlocks), so we also need to trim it for the key
                     TranslationHandler.AddDialogue(text, true, name);
                 }
 
                 xmlText = xmlNode2.SelectNodes("DialogueOptionsList/DialogueOption/Text");
-                foreach (object Page in xmlText)
+                foreach (object option in xmlText)
                 {
-                    XmlNode pageData = (XmlNode)Page;
-                    var text = pageData.InnerText;
+                    XmlNode optionData = (XmlNode)option;
+                    var text = optionData.InnerText;
                     // The text is trimmed in CharacterDialogueTree.LoadXml, so we also need to trim it for the key
                     TranslationHandler.AddDialogue(text, true, characterName, name);
                 }

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -211,7 +211,7 @@ namespace NewHorizons.Builder.Props
                 {
                     XmlNode pageData = (XmlNode)Page;
                     var text = pageData.InnerText;
-                    // The text is trimmed in CharacterDialogueTree.LoadXml, so we also need to trim it for the key
+                    // The text is trimmed in DialogueText constructor (_listTextBlocks), so we also need to trim it for the key
                     TranslationHandler.AddDialogue(text, true, name);
                 }
 
@@ -220,7 +220,7 @@ namespace NewHorizons.Builder.Props
                 {
                     XmlNode pageData = (XmlNode)Page;
                     var text = pageData.InnerText;
-                    // The text is trimmed in DialogueText constructor (_listTextBlocks), so we also need to trim it for the key
+                    // The text is trimmed in CharacterDialogueTree.LoadXml, so we also need to trim it for the key
                     TranslationHandler.AddDialogue(text, true, characterName, name);
                 }
             }

--- a/NewHorizons/Handlers/TranslationHandler.cs
+++ b/NewHorizons/Handlers/TranslationHandler.cs
@@ -100,9 +100,9 @@ namespace NewHorizons.Handlers
             }
         }
 
-        public static void AddDialogue(string rawText, params string[] rawPreText)
+        public static void AddDialogue(string rawText, bool trimRawTextForKey = false, params string[] rawPreText)
         {
-            var key = string.Join(string.Empty, rawPreText) + rawText;
+            var key = string.Join(string.Empty, rawPreText) + (trimRawTextForKey? rawText.Trim() : rawText);
 
             var text = GetTranslation(rawText, TextType.DIALOGUE);
 


### PR DESCRIPTION
<!-- A new module or something else important -->
## Major features
-

<!-- A new parameter added to a module, or API feature -->
## Minor features
-

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
-

<!-- Be sure to reference the existing issue if it exists -->
## Bug fixes
- The game trims the text of `Page` and `DialogOption` and this is used in the key that indexes the translation table. However, this trim was missing in NH, causing the game to fail to find the translation (and displaying the key as a fallback). For example, [this](https://github.com/FixxionsLair/Secret-Words/blob/78dd665323d745f88cd4bd531c13f29020233a06/planets/Dialogue/Fixxion.xml#L46) would cause the error `String "1Jötunn is a really cold planet, it's kinda hard to live in and it's so dark but" not found in table for language ENG` because there is an space at the end of the string and the game displays "1Jötunn is a really cold planet, it's kinda hard to live in and it's so dark but" with the "1" at the start.
