### PR TITLE
Vision torch image loading bug

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -95,7 +95,7 @@ namespace NewHorizons.Builder.Props
                 var slide = new Slide();
                 var slideInfo = info.slides[i];
 
-                imageLoader.pathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
+                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
 
                 AddModules(slideInfo, ref slide, mod);
 
@@ -197,7 +197,7 @@ namespace NewHorizons.Builder.Props
                 var slide = new Slide();
                 var slideInfo = info.slides[i];
 
-                imageLoader.pathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
+                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
 
                 AddModules(slideInfo, ref slide, mod);
 
@@ -263,7 +263,7 @@ namespace NewHorizons.Builder.Props
                 var slide = new Slide();
                 var slideInfo = slides[i];
 
-                imageLoader.pathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
+                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
 
                 AddModules(slideInfo, ref slide, mod);
 
@@ -336,7 +336,7 @@ namespace NewHorizons.Builder.Props
                 var slide = new Slide();
                 var slideInfo = slides[i];
 
-                imageLoader.pathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
+                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
 
                 AddModules(slideInfo, ref slide, mod);
 

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -2,8 +2,10 @@ using NewHorizons.External.Modules;
 using NewHorizons.Handlers;
 using NewHorizons.Utility;
 using OWML.Common;
+using OWML.Common.Menus;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using UnityEngine;
 using static NewHorizons.External.Modules.PropModule;
 using Logger = NewHorizons.Utility.Logger;
@@ -89,19 +91,8 @@ namespace NewHorizons.Builder.Props
             // The base game ones only have 15 slides max
             var textures = new Texture2D[slidesCount >= 15 ? 15 : slidesCount];
 
-            var imageLoader = slideReelObj.AddComponent<ImageUtilities.AsyncImageLoader>();
-            for (int i = 0; i < slidesCount; i++)
-            {
-                var slide = new Slide();
-                var slideInfo = info.slides[i];
+            var imageLoader = AddAsyncLoader(slideReelObj, mod, info.slides, ref slideCollection);
 
-                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
-
-                AddModules(slideInfo, ref slide, mod);
-
-                slideCollection.slides[i] = slide;
-            }
-            
             // this variable just lets us track how many of the first 15 slides have been loaded.
             // this way as soon as the last one is loaded (due to async loading, this may be
             // slide 7, or slide 3, or whatever), we can build the slide reel texture. This allows us
@@ -191,18 +182,7 @@ namespace NewHorizons.Builder.Props
             int slidesCount = info.slides.Length;
             var slideCollection = new SlideCollection(slidesCount);
             
-            var imageLoader = projectorObj.AddComponent<ImageUtilities.AsyncImageLoader>();
-            for (int i = 0; i < slidesCount; i++)
-            {
-                var slide = new Slide();
-                var slideInfo = info.slides[i];
-
-                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
-
-                AddModules(slideInfo, ref slide, mod);
-
-                slideCollection.slides[i] = slide;
-            }
+            var imageLoader = AddAsyncLoader(projectorObj, mod, info.slides, ref slideCollection);
             imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index]._image = ImageUtilities.Invert(tex); });
 
             slideCollectionContainer.slideCollection = slideCollection;
@@ -256,19 +236,7 @@ namespace NewHorizons.Builder.Props
             var slidesCount = slides.Length;
             var slideCollection = new SlideCollection(slidesCount);
 
-        
-            var imageLoader = g.AddComponent<ImageUtilities.AsyncImageLoader>();
-            for (int i = 0; i < slidesCount; i++)
-            {
-                var slide = new Slide();
-                var slideInfo = slides[i];
-
-                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
-
-                AddModules(slideInfo, ref slide, mod);
-
-                slideCollection.slides[i] = slide;
-            }
+            var imageLoader = AddAsyncLoader(g, mod, info.slides, ref slideCollection);
             imageLoader.imageLoadedEvent.AddListener((Texture2D tex, int index) => { slideCollection.slides[index]._image = tex; });
 
             // attach a component to store all the data for the slides that play when a vision torch scans this target
@@ -330,19 +298,8 @@ namespace NewHorizons.Builder.Props
             var slidesCount = slides.Length;
             var slideCollection = new SlideCollection(slidesCount);
 
-            var imageLoader = standingTorch.AddComponent<ImageUtilities.AsyncImageLoader>();
-            for (int i = 0; i < slidesCount; i++)
-            {
-                var slide = new Slide();
-                var slideInfo = slides[i];
+            var imageLoader = AddAsyncLoader(standingTorch, mod, slides, ref slideCollection);
 
-                imageLoader.PathsToLoad.Add(mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath);
-
-                AddModules(slideInfo, ref slide, mod);
-
-                slideCollection.slides[i] = slide;
-            }
-            
             // This variable just lets us track how many of the slides have been loaded.
             // This way as soon as the last one is loaded (due to async loading, this may be
             // slide 7, or slide 3, or whatever), we can enable the vision torch. This allows us
@@ -376,6 +333,32 @@ namespace NewHorizons.Builder.Props
             if (info.reveals != null) slideCollectionContainer._shipLogOnComplete = string.Join(",", info.reveals);
 
             return standingTorch;
+        }
+
+        private static ImageUtilities.AsyncImageLoader AddAsyncLoader(GameObject gameObject, IModBehaviour mod, SlideInfo[] slides, ref SlideCollection slideCollection)
+        {
+            var imageLoader = gameObject.AddComponent<ImageUtilities.AsyncImageLoader>();
+            for (int i = 0; i < slides.Length; i++)
+            {
+                var slide = new Slide();
+                var slideInfo = slides[i];
+
+                if (string.IsNullOrEmpty(slideInfo.imagePath))
+                {
+                    imageLoader.imageLoadedEvent?.Invoke(Texture2D.blackTexture, i);
+                }
+                else
+                {
+                    // Don't use Path.Combine here else you break the Vision
+                    imageLoader.PathsToLoad.Add((i, mod.ModHelper.Manifest.ModFolderPath + slideInfo.imagePath));
+                }
+
+                AddModules(slideInfo, ref slide, mod);
+
+                slideCollection.slides[i] = slide;
+            }
+
+            return imageLoader;
         }
 
         private static void AddModules(PropModule.SlideInfo slideInfo, ref Slide slide, IModBehaviour mod)

--- a/NewHorizons/Utility/ImageUtilities.cs
+++ b/NewHorizons/Utility/ImageUtilities.cs
@@ -1,9 +1,11 @@
 using OWML.Common;
+using OWML.ModHelper;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Policy;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Networking;
@@ -364,7 +366,7 @@ namespace NewHorizons.Utility
         // Modified from https://stackoverflow.com/a/69141085/9643841
         public class AsyncImageLoader : MonoBehaviour
         {
-            public List<string> PathsToLoad { get; private set; } = new ();
+            public List<(int index, string path)> PathsToLoad { get; private set; } = new ();
 
             public class ImageLoadedEvent : UnityEvent<Texture2D, int> { }
             public ImageLoadedEvent imageLoadedEvent = new ();
@@ -381,9 +383,9 @@ namespace NewHorizons.Utility
             void Start()
             {
                 imageLoadedEvent.AddListener(OnImageLoaded);
-                for (int i = 0; i < PathsToLoad.Count; i++)
+                foreach (var (index, path) in PathsToLoad)
                 {
-                    StartCoroutine(DownloadTexture(PathsToLoad[i], i));
+                    StartCoroutine(DownloadTexture(path, index));
                 }
             }
 
@@ -403,12 +405,6 @@ namespace NewHorizons.Utility
 
             IEnumerator DownloadTexture(string url, int index)
             {
-                if (string.IsNullOrEmpty(url))
-                {
-                    imageLoadedEvent?.Invoke(Texture2D.blackTexture, index);
-                    yield break;
-                }
-
                 lock(_loadedTextures)
                 {
                     if (_loadedTextures.ContainsKey(url))

--- a/NewHorizons/Utility/ImageUtilities.cs
+++ b/NewHorizons/Utility/ImageUtilities.cs
@@ -403,6 +403,12 @@ namespace NewHorizons.Utility
 
             IEnumerator DownloadTexture(string url, int index)
             {
+                if (string.IsNullOrEmpty(url))
+                {
+                    imageLoadedEvent?.Invoke(Texture2D.blackTexture, index);
+                    yield break;
+                }
+
                 lock(_loadedTextures)
                 {
                     if (_loadedTextures.ContainsKey(url))

--- a/NewHorizons/Utility/ImageUtilities.cs
+++ b/NewHorizons/Utility/ImageUtilities.cs
@@ -3,10 +3,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.Networking;
-using UnityEngine.UIElements;
 
 namespace NewHorizons.Utility
 {
@@ -128,7 +128,7 @@ namespace NewHorizons.Utility
             var texture = (new Texture2D(size * 4, size * 4, TextureFormat.ARGB32, false));
             texture.name = "SlideReelAtlas";
 
-            Color[] fillPixels = new Color[size * size * 4 * 4];
+            var fillPixels = new Color[size * size * 4 * 4];
             for (int xIndex = 0; xIndex < 4; xIndex++)
             {
                 for (int yIndex = 0; yIndex < 4; yIndex++)
@@ -276,8 +276,8 @@ namespace NewHorizons.Utility
         {
             var tex = (new Texture2D(1, 1, TextureFormat.ARGB32, false));
             tex.name = "Clear";
-            Color fillColor = Color.clear;
-            Color[] fillPixels = new Color[tex.width * tex.height];
+            var fillColor = Color.clear;
+            var fillPixels = new Color[tex.width * tex.height];
             for (int i = 0; i < fillPixels.Length; i++)
             {
                 fillPixels[i] = fillColor;
@@ -296,7 +296,7 @@ namespace NewHorizons.Utility
         {
             var tex = (new Texture2D(width, height, TextureFormat.ARGB32, false));
             tex.name = src.name + "CanvasScaled";
-            Color[] fillPixels = new Color[tex.width * tex.height];
+            var fillPixels = new Color[tex.width * tex.height];
             for (int i = 0; i < tex.width; i++)
             {
                 for (int j = 0; j < tex.height; j++)
@@ -339,14 +339,14 @@ namespace NewHorizons.Utility
         }
         public static Texture2D MakeSolidColorTexture(int width, int height, Color color)
         {
-            Color[] pixels = new Color[width*height];
+            var pixels = new Color[width*height];
  
             for(int i = 0; i < pixels.Length; i++)
             {
                 pixels[i] = color;
             }
  
-            Texture2D newTexture = new Texture2D(width, height);
+            var newTexture = new Texture2D(width, height);
             newTexture.SetPixels(pixels);
             newTexture.Apply();
             return newTexture;
@@ -364,10 +364,15 @@ namespace NewHorizons.Utility
         // Modified from https://stackoverflow.com/a/69141085/9643841
         public class AsyncImageLoader : MonoBehaviour
         {
-            public List<string> pathsToLoad = new List<string>();
+            public List<string> PathsToLoad { get; private set; } = new ();
 
             public class ImageLoadedEvent : UnityEvent<Texture2D, int> { }
-            public ImageLoadedEvent imageLoadedEvent = new ImageLoadedEvent();
+            public ImageLoadedEvent imageLoadedEvent = new ();
+
+            private readonly object _lockObj = new();
+
+            public bool FinishedLoading { get; private set; }
+            private int _loadedCount = 0;
 
             // TODO: set up an optional “StartLoading” and “StartUnloading” condition on AsyncTextureLoader,
             // and make use of that for at least for projector stuff (require player to be in the same sector as the slides
@@ -375,39 +380,59 @@ namespace NewHorizons.Utility
 
             void Start()
             {
-                for (int i = 0; i < pathsToLoad.Count; i++)
+                imageLoadedEvent.AddListener(OnImageLoaded);
+                for (int i = 0; i < PathsToLoad.Count; i++)
                 {
-                    StartCoroutine(DownloadTexture(pathsToLoad[i], i));
+                    StartCoroutine(DownloadTexture(PathsToLoad[i], i));
+                }
+            }
+
+            private void OnImageLoaded(Texture texture, int index)
+            {
+                lock (_lockObj)
+                {
+                    _loadedCount++;
+
+                    if (_loadedCount >= PathsToLoad.Count)
+                    {
+                        Logger.LogVerbose($"Finished loading all textures for {gameObject.name} (one was {PathsToLoad.FirstOrDefault()}");
+                        FinishedLoading = true;
+                    }
                 }
             }
 
             IEnumerator DownloadTexture(string url, int index)
             {
-                if (_loadedTextures.ContainsKey(url))
+                lock(_loadedTextures)
                 {
-                    Logger.LogVerbose($"Already loaded image at path: {url}");
-                    var texture = _loadedTextures[url];
-                    imageLoadedEvent.Invoke(texture, index);
-                    yield break;
+                    if (_loadedTextures.ContainsKey(url))
+                    {
+                        Logger.LogVerbose($"Already loaded image {index}:{url}");
+                        var texture = _loadedTextures[url];
+                        imageLoadedEvent?.Invoke(texture, index);
+                        yield break;
+                    }
                 }
 
-                using (UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(url))
+                using UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(url);
+
+                yield return uwr.SendWebRequest();
+
+                var hasError = uwr.error != null && uwr.error != "";
+
+                if (hasError) 
                 {
-                    yield return uwr.SendWebRequest();
+                    Logger.LogError($"Failed to load {index}:{url} - {uwr.error}");
+                }
+                else
+                {
+                    var texture = DownloadHandlerTexture.GetContent(uwr);
 
-                    var hasError = uwr.error != null && uwr.error != "";
-                
-                    if (hasError) // (uwr.result != UnityWebRequest.Result.Success)
+                    lock(_loadedTextures)
                     {
-                        Debug.Log(uwr.error);
-                    }
-                    else
-                    {
-                        var texture = DownloadHandlerTexture.GetContent(uwr);
-
                         if (_loadedTextures.ContainsKey(url))
                         {
-                            Logger.LogVerbose($"Already loaded image at path: {url}");
+                            Logger.LogVerbose($"Already loaded image {index}:{url}");
                             Destroy(texture);
                             texture = _loadedTextures[url];
                         }
@@ -416,7 +441,7 @@ namespace NewHorizons.Utility
                             _loadedTextures.Add(url, texture);
                         }
 
-                        imageLoadedEvent.Invoke(texture, index);
+                        imageLoadedEvent?.Invoke(texture, index);
                     }
                 }
             }


### PR DESCRIPTION
Makes it handle slides with no path better, properly log errors when it fails to load images, added tracking for if the image is loaded yet or not (unused currently, could disable the slide/vision target if the image don't load?).
