### PR TITLE
1.6.1

### DIFF
--- a/NewHorizons/Assets/addon-manifest.json
+++ b/NewHorizons/Assets/addon-manifest.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Outer-Wilds-New-Horizons/new-horizons/main/NewHorizons/Schemas/addon_manifest_schema.json",
   "credits": [
     "xen#Mod Director\n#Programmer",
     "Bwc9876#Mod Manager\n#Programmer\n#Dev Ops",

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Builder.General;
 using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
 using NewHorizons.Handlers;
@@ -100,6 +101,7 @@ namespace NewHorizons.Builder.Props
 
             prop.transform.localScale = detail.stretch ?? (detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale);
 
+            if (!detail.keepLoaded) GroupsBuilder.Make(prop, sector);
             prop.SetActive(true);
 
             if (prop == null) return null;

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -98,7 +98,7 @@ namespace NewHorizons.Builder.Props
                 prop.transform.rotation = go.transform.TransformRotation(rot);
             }
 
-            prop.transform.localScale = detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale;
+            prop.transform.localScale = detail.stretch ?? (detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale);
 
             prop.SetActive(true);
 

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -101,11 +101,6 @@ namespace NewHorizons.Builder.Props
 
             prop.transform.localScale = detail.stretch ?? (detail.scale != 0 ? Vector3.one * detail.scale : prefab.transform.localScale);
 
-            if (!detail.keepLoaded) GroupsBuilder.Make(prop, sector);
-            prop.SetActive(true);
-
-            if (prop == null) return null;
-
             if (detail.removeChildren != null)
             {
                 var detailPath = prop.transform.GetPath();
@@ -160,6 +155,9 @@ namespace NewHorizons.Builder.Props
                     prop.transform.parent = newParent.transform;
                 }
             }
+
+            if (!detail.keepLoaded) GroupsBuilder.Make(prop, sector);
+            prop.SetActive(true);
 
             return prop;
         }

--- a/NewHorizons/Builder/Props/NomaiTextBuilder.cs
+++ b/NewHorizons/Builder/Props/NomaiTextBuilder.cs
@@ -48,7 +48,11 @@ namespace NewHorizons.Builder.Props
         private static void InitPrefabs()
         {
             // Just take every scroll and get the first arc
-            var existingArcs = GameObject.FindObjectsOfType<ScrollItem>().Select(x => x?._nomaiWallText?.gameObject?.transform?.Find("Arc 1")?.gameObject).Where(x => x != null).ToArray();
+            var existingArcs = GameObject.FindObjectsOfType<ScrollItem>()
+                .Select(x => x?._nomaiWallText?.gameObject?.transform?.Find("Arc 1")?.gameObject)
+                .Where(x => x != null)
+                .OrderBy(x => x.transform.GetPath()) // order by path so game updates dont break things
+                .ToArray();
             _arcPrefabs = new List<GameObject>();
             _childArcPrefabs = new List<GameObject>();
             foreach (var existingArc in existingArcs)
@@ -67,7 +71,11 @@ namespace NewHorizons.Builder.Props
                 }
             }
 
-            var existingGhostArcs = GameObject.FindObjectsOfType<GhostWallText>().Select(x => x?._textLine?.gameObject).Where(x => x != null).ToArray();
+            var existingGhostArcs = GameObject.FindObjectsOfType<GhostWallText>()
+                .Select(x => x?._textLine?.gameObject)
+                .Where(x => x != null)
+                .OrderBy(x => x.transform.GetPath()) // order by path so game updates dont break things
+                .ToArray();
             _ghostArcPrefabs = new List<GameObject>();
             foreach (var existingArc in existingGhostArcs)
             {

--- a/NewHorizons/Builder/Props/RemoteBuilder.cs
+++ b/NewHorizons/Builder/Props/RemoteBuilder.cs
@@ -106,7 +106,9 @@ namespace NewHorizons.Builder.Props
 
             var id = RemoteHandler.GetPlatformID(info.id);
 
-            var decal = ImageUtilities.GetTexture(mod, info.decalPath, false, false);
+            Texture2D decal = Texture2D.whiteTexture;
+            if (!string.IsNullOrWhiteSpace(info.decalPath)) decal = ImageUtilities.GetTexture(mod, info.decalPath, false, false);
+            else Logger.LogError($"Missing decal path on [{info.id}] for [{go.name}]");
 
             if (info.platform != null)
             {

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -69,6 +69,7 @@ namespace NewHorizons.Builder.Props
                 var detailInfo = new PropModule.DetailInfo()
                 {
                     scale = propInfo.scale,
+                    stretch = propInfo.stretch,
 					keepLoaded = propInfo.keepLoaded
                 };
                 var scatterPrefab = DetailBuilder.Make(go, sector, prefab, detailInfo);

--- a/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
@@ -206,7 +206,7 @@ namespace NewHorizons.Builder.ShipLog
 
         private static Sprite GetEntrySprite(string entryId, NewHorizonsBody body, bool logError)
         {
-            string relativePath = body.Config.ShipLog.spriteFolder + "/" + entryId + ".png";
+            string relativePath = Path.Combine(body.Config.ShipLog.spriteFolder, entryId + ".png");
             try
             {
                 Texture2D newTexture = ImageUtilities.GetTexture(body.Mod, relativePath);

--- a/NewHorizons/Builder/Volumes/AudioVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/AudioVolumeBuilder.cs
@@ -46,6 +46,7 @@ namespace NewHorizons.Builder.Volumes
             var owAudioSource = go.AddComponent<OWAudioSource>();
             owAudioSource._audioSource = audioSource;
             owAudioSource.loop = info.loop;
+            owAudioSource.SetMaxVolume(info.volume);
             owAudioSource.SetTrack((OWAudioMixer.TrackName)Enum.Parse(typeof(OWAudioMixer.TrackName), Enum.GetName(typeof(AudioMixerTrackName), info.track)));
             AudioUtilities.SetAudioClip(owAudioSource, info.audio, mod);
 

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -201,6 +201,11 @@ namespace NewHorizons.External.Modules
             [DefaultValue(1f)] public float scale = 1f;
 
             /// <summary>
+            /// Scale each axis of the prop. Overrides `scale`.
+            /// </summary>
+            public MVector3 stretch;
+
+            /// <summary>
             /// If this value is not null, this prop will be quantum. Assign this field to the id of the quantum group it should be a part of. The group it is assigned to determines what kind of quantum object it is
             /// </summary>
             public string quantumGroupID;

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -123,7 +123,12 @@ namespace NewHorizons.External.Modules
             /// <summary>
             /// Scale this prop once it is placed
             /// </summary>
-            public float scale = 1f;
+            [DefaultValue(1f)] public float scale = 1f;
+
+            /// <summary>
+            /// Scale each axis of the prop. Overrides `scale`.
+            /// </summary>
+            public MVector3 stretch;
 
             /// <summary>
             /// The number used as entropy for scattering the props

--- a/NewHorizons/External/Modules/VolumesModule.cs
+++ b/NewHorizons/External/Modules/VolumesModule.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Text;
@@ -134,6 +135,13 @@ namespace NewHorizons.External.Modules
             /// Whether to loop this audio while in this audio volume or just play it once
             /// </summary>
             [DefaultValue(true)] public bool loop = true;
+
+            /// <summary>
+            /// The loudness of the audio
+            /// </summary>
+            [Range(0f, 1f)]
+            [DefaultValue(1f)]
+            public float volume = 1f;
         }
 
         [JsonObject]

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -571,11 +571,11 @@ namespace NewHorizons
                     }
                 }
                 // Has to go before translations for achievements
-                if (File.Exists(folder + "addon-manifest.json"))
+                if (File.Exists(Path.Combine(folder, "addon-manifest.json")))
                 {
                     LoadAddonManifest("addon-manifest.json", mod);
                 }
-                if (Directory.Exists(folder + @"translations\"))
+                if (Directory.Exists(Path.Combine(folder, "translations")))
                 {
                     LoadTranslations(folder, mod);
                 }
@@ -603,15 +603,15 @@ namespace NewHorizons
             var foundFile = false;
             foreach (TextTranslation.Language language in Enum.GetValues(typeof(TextTranslation.Language)))
             {
-                if (language == TextTranslation.Language.UNKNOWN || language == TextTranslation.Language.TOTAL) continue;
+                if (language is TextTranslation.Language.UNKNOWN or TextTranslation.Language.TOTAL) continue;
 
-                var relativeFile = $"translations/{language.ToString().ToLower()}.json";
+                var relativeFile = Path.Combine("translations", language.ToString().ToLower() + ".json");
 
-                if (File.Exists($"{folder}{relativeFile}"))
+                if (File.Exists(Path.Combine(folder, relativeFile)))
                 {
                     Logger.LogVerbose($"Registering {language} translation from {mod.ModHelper.Manifest.Name} from {relativeFile}");
 
-                    var config = new TranslationConfig($"{folder}{relativeFile}");
+                    var config = new TranslationConfig(Path.Combine(folder, relativeFile));
 
                     foundFile = true;
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1049,6 +1049,10 @@
           "format": "float",
           "default": 1.0
         },
+        "stretch": {
+          "description": "Scale each axis of the prop. Overrides `scale`.",
+          "$ref": "#/definitions/MVector3"
+        },
         "quantumGroupID": {
           "type": "string",
           "description": "If this value is not null, this prop will be quantum. Assign this field to the id of the quantum group it should be a part of. The group it is assigned to determines what kind of quantum object it is"

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2501,6 +2501,14 @@
           "type": "boolean",
           "description": "Whether to loop this audio while in this audio volume or just play it once",
           "default": true
+        },
+        "volume": {
+          "type": "number",
+          "description": "The loudness of the audio",
+          "format": "float",
+          "default": 1.0,
+          "maximum": 1.0,
+          "minimum": 0.0
         }
       }
     },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1376,7 +1376,12 @@
         "scale": {
           "type": "number",
           "description": "Scale this prop once it is placed",
-          "format": "float"
+          "format": "float",
+          "default": 1.0
+        },
+        "stretch": {
+          "description": "Scale each axis of the prop. Overrides `scale`.",
+          "$ref": "#/definitions/MVector3"
         },
         "seed": {
           "type": "integer",

--- a/NewHorizons/Utility/DebugUtilities/DebugRaycaster.cs
+++ b/NewHorizons/Utility/DebugUtilities/DebugRaycaster.cs
@@ -19,24 +19,31 @@ namespace NewHorizons.Utility.DebugUtilities
 
         private ScreenPrompt _raycastPrompt;
 
-        private void Awake()
+        private void Start()
         {
             _rb = this.GetRequiredComponent<OWRigidbody>();
 
-            _raycastPrompt = new ScreenPrompt(TranslationHandler.GetTranslation("DEBUG_RAYCAST", TranslationHandler.TextType.UI) + " <CMD>", ImageUtilities.GetButtonSprite(KeyCode.P));
-
-            Locator.GetPromptManager().AddScreenPrompt(_raycastPrompt, PromptPosition.UpperRight, false);
+            if (_raycastPrompt == null)
+            {
+                _raycastPrompt = new ScreenPrompt(TranslationHandler.GetTranslation("DEBUG_RAYCAST", TranslationHandler.TextType.UI) + " <CMD>", ImageUtilities.GetButtonSprite(KeyCode.P));
+                Locator.GetPromptManager().AddScreenPrompt(_raycastPrompt, PromptPosition.UpperRight, false);
+            }
         }
         
         private void OnDestroy()
         {
-            Locator.GetPromptManager()?.RemoveScreenPrompt(_raycastPrompt, PromptPosition.UpperRight);
+            if (_raycastPrompt != null)
+            {
+                Locator.GetPromptManager()?.RemoveScreenPrompt(_raycastPrompt, PromptPosition.UpperRight);
+            }
         }
 
         private void Update()
         {
             UpdatePromptVisibility();
+
             if (!Main.Debug) return;
+
             if (Keyboard.current == null) return;
 
             if (Keyboard.current[Key.P].wasReleasedThisFrame)
@@ -48,7 +55,10 @@ namespace NewHorizons.Utility.DebugUtilities
 
         public void UpdatePromptVisibility()
         {
-            _raycastPrompt.SetVisibility(!OWTime.IsPaused() && Main.Debug);
+            if (_raycastPrompt != null)
+            {
+                _raycastPrompt.SetVisibility(!OWTime.IsPaused() && Main.Debug);
+            }
         }
 
 

--- a/NewHorizons/Utility/NewHorizonBody.cs
+++ b/NewHorizons/Utility/NewHorizonBody.cs
@@ -1,5 +1,6 @@
-﻿using NewHorizons.External.Configs;
+using NewHorizons.External.Configs;
 using OWML.Common;
+using System.Linq;
 using UnityEngine;
 namespace NewHorizons.Utility
 {
@@ -10,6 +11,8 @@ namespace NewHorizons.Utility
             Config = config;
             Mod = mod;
             RelativePath = relativePath;
+
+            Migrate();
         }
 
         public PlanetConfig Config;
@@ -17,5 +20,31 @@ namespace NewHorizons.Utility
         public string RelativePath;
 
         public GameObject Object;
+
+        #region Migration
+        private static readonly string[] _keepLoadedModsList = new string[]
+        {
+            "CreativeNameTxt.theirhomeworld",
+            "Roggsy.enterthewarioverse",
+            "Jammer.jammerlore",
+            "ErroneousCreationist.solarneighbourhood",
+            "ErroneousCreationist.incursionfinaldawn"
+        };
+
+        private void Migrate()
+        {
+            // Some old mods get really broken by this change in 1.6.1
+            if (_keepLoadedModsList.Contains(Mod.ModHelper.Manifest.UniqueName))
+            {
+                if (Config?.Props?.details != null)
+                {
+                    foreach (var detail in Config.Props.details)
+                    {
+                        detail.keepLoaded = true;
+                    }
+                }
+            }
+        }
+        #endregion
     }
 }

--- a/NewHorizons/Utility/SearchUtilities.cs
+++ b/NewHorizons/Utility/SearchUtilities.cs
@@ -119,7 +119,7 @@ namespace NewHorizons.Utility
 
             var name = names.Last();
             if (warn) Logger.LogWarning($"Couldn't find object in path {path}, will look for potential matches for name {name}");
-            // 3: find resource to include inactive objects (but skip prefabs
+            // 3: find resource to include inactive objects (but skip prefabs)
             go = Resources.FindObjectsOfTypeAll<GameObject>()
                 .FirstOrDefault(x => x.name == name && x.scene.name != null);
             if (go)

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Hawkbar, Trifid, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "owmlVersion": "2.6.0",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_Randomizer" ],


### PR DESCRIPTION
## Minor features
- Added new `stretch` option to scatter and details, allowing setting the local scale on the x, y, and z axes.
- Added `volume` option to AudioVolumes for setting how loud the audio is.

## Bug fixes
- Reimplemented group builder that was accidentally disabled. 
- Fix components flagged to be removed throwing errors on Awake
- Hardcoded backwards compat for mods broken by keepLoaded = false like WARIO
- Fixed two debug raycast prompts appearing
- Sorted Nomai text prefabs to (hopefully) stop future updates breaking them again (you have to re-orient them still since patch 13, sorry)
- Fixed some more paths that might be broken on Linux