### PR TITLE
Implement #389 playWithShipLogFacts, fix #392

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -130,8 +130,7 @@ namespace NewHorizons.Builder.Props
 
             slideCollectionContainer.slideCollection = slideCollection;
 
-            // Idk why but it wants reveals to be comma delimited not a list
-            if (info.reveals != null) slideCollectionContainer._shipLogOnComplete = string.Join(",", info.reveals);
+            LinkShipLogFacts(info, slideCollectionContainer);
 
             StreamingHandler.SetUpStreaming(slideReelObj, sector);
 
@@ -245,8 +244,7 @@ namespace NewHorizons.Builder.Props
             target.slideCollection = g.AddComponent<MindSlideCollection>();
             target.slideCollection._slideCollectionContainer = slideCollectionContainer;
 
-            // Idk why but it wants reveals to be comma delimited not a list
-            if (info.reveals != null) slideCollectionContainer._shipLogOnComplete = string.Join(",", info.reveals);
+            LinkShipLogFacts(info, slideCollectionContainer);
 
             return g;
         }
@@ -324,11 +322,12 @@ namespace NewHorizons.Builder.Props
             mindSlideCollection._slideCollectionContainer = slideCollectionContainer;
 
             // Make sure that these slides play when the player wanders into the beam
+            slideCollectionContainer._initialized = true; // Hack to avoid initialization in the following call (it would throw NRE)
             mindSlideProjector.SetMindSlideCollection(mindSlideCollection);
+            slideCollectionContainer._initialized = false;
 
 
-            // Idk why but it wants reveals to be comma delimited not a list
-            if (info.reveals != null) slideCollectionContainer._shipLogOnComplete = string.Join(",", info.reveals);
+            LinkShipLogFacts(info, slideCollectionContainer);
 
             return standingTorch;
         }
@@ -404,6 +403,14 @@ namespace NewHorizons.Builder.Props
             }
 
             Slide.WriteModules(modules, ref slide._modulesList, ref slide._modulesData, ref slide.lengths);
+        }
+        
+        private static void LinkShipLogFacts(ProjectionInfo info, SlideCollectionContainer slideCollectionContainer)
+        {
+            // Idk why but it wants reveals to be comma delimited not a list
+            if (info.reveals != null) slideCollectionContainer._shipLogOnComplete = string.Join(",", info.reveals);
+            // Don't use null value, NRE in SlideCollectionContainer.Initialize
+            slideCollectionContainer._playWithShipLogFacts = info.playWithShipLogFacts ?? Array.Empty<string>();
         }
     }
 

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -321,13 +321,9 @@ namespace NewHorizons.Builder.Props
             var mindSlideCollection = standingTorch.AddComponent<MindSlideCollection>();
             mindSlideCollection._slideCollectionContainer = slideCollectionContainer;
 
-            // Make sure that these slides play when the player wanders into the beam
-            slideCollectionContainer._initialized = true; // Hack to avoid initialization in the following call (it would throw NRE)
-            mindSlideProjector.SetMindSlideCollection(mindSlideCollection);
-            slideCollectionContainer._initialized = false;
-
-
             LinkShipLogFacts(info, slideCollectionContainer);
+
+            mindSlideProjector.SetMindSlideCollection(mindSlideCollection);
 
             return standingTorch;
         }

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -612,9 +612,17 @@ namespace NewHorizons.External.Modules
             public MVector3 position;
 
             /// <summary>
-            /// The ship log entries revealed after finishing this slide reel.
+            /// The ship log facts revealed after finishing this slide reel.
             /// </summary>
             public string[] reveals;
+
+            /// <summary>
+            /// The ship log facts that make the reel play when they are displayed in the computer (by selecting entries or arrows).
+            /// You should probably include facts from `reveals` here.
+            /// If you only specify a rumor fact, then it would only play in its ship log entry if this has revealed only
+            /// rumor facts because an entry with revealed explore facts doesn't display rumor facts.
+            /// </summary>
+            public string[] playWithShipLogFacts;
 
             /// <summary>
             /// The rotation of this slideshow.
@@ -707,7 +715,7 @@ namespace NewHorizons.External.Modules
             // SlideShipLogEntryModule
 
             /// <summary>
-            /// Ship log entry revealed when viewing this slide
+            /// Ship log fact revealed when viewing this slide
             /// </summary>
             public string reveal;
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1419,7 +1419,14 @@
         },
         "reveals": {
           "type": "array",
-          "description": "The ship log entries revealed after finishing this slide reel.",
+          "description": "The ship log facts revealed after finishing this slide reel.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "playWithShipLogFacts": {
+          "type": "array",
+          "description": "The ship log facts that make the reel play when they are displayed in the computer (by selecting entries or arrows).\nYou should probably include facts from `reveals` here.\nIf you only specify a rumor fact, then it would only play in its ship log entry if this has revealed only\nrumor facts because an entry with revealed explore facts doesn't display rumor facts.",
           "items": {
             "type": "string"
           }
@@ -1498,7 +1505,7 @@
         },
         "reveal": {
           "type": "string",
-          "description": "Ship log entry revealed when viewing this slide"
+          "description": "Ship log fact revealed when viewing this slide"
         },
         "spotIntensityMod": {
           "type": "number",


### PR DESCRIPTION
## Major features
- Added `playWithShipLogFacts ` to `slideShows` to make reels play in ship log computer.. #389

## Bug fixes
- Fix NRE errors caused by visions (`visionTorchTarget` and `standingVisionTorch`) initialization. #392
- Fix reels (`slideReel`) showing up in Echoes of the Eye entries replacing the vanilla reel:
![reel](https://user-images.githubusercontent.com/22490080/194959455-9a1d02d7-a5d3-41d8-8d3f-f9c15f92b9ea.jpg)
