### PR TITLE
dont touch backslashes

### DIFF
--- a/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
+++ b/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
@@ -2,6 +2,7 @@ using NewHorizons.Handlers;
 using NewHorizons.Utility;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
@@ -131,7 +132,7 @@ namespace NewHorizons.Components.ShipLog
                 }
                 else
                 {
-                    var path = $"planets/{uniqueID}.png";
+                    var path = Path.Combine("planets", uniqueID + ".png");
                     Logger.LogVerbose($"ShipLogStarChartManager - Trying to load {path}");
                     texture = ImageUtilities.GetTexture(Main.SystemDict[uniqueID].Mod, path);
                 }

--- a/NewHorizons/External/NewHorizonsData.cs
+++ b/NewHorizons/External/NewHorizonsData.cs
@@ -25,7 +25,7 @@ namespace NewHorizons.External
 
             try
             {
-                _saveFile = Main.Instance.ModHelper.Storage.Load<NewHorizonsSaveFile>(FileName);
+                _saveFile = Main.Instance.ModHelper.Storage.Load<NewHorizonsSaveFile>(FileName, false);
                 if (!_saveFile.Profiles.ContainsKey(_activeProfileName))
                     _saveFile.Profiles.Add(_activeProfileName, new NewHorizonsProfile());
                 _activeProfile = _saveFile.Profiles[_activeProfileName];

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -582,7 +582,7 @@ namespace NewHorizons
                         Logger.LogVerbose($"Loading system {name}");
 
                         var relativePath = file.Replace(folder, "");
-                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath);
+                        var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(relativePath, false);
                         starSystemConfig.Migrate();
                         starSystemConfig.FixCoordinates();
 
@@ -656,7 +656,7 @@ namespace NewHorizons
         {
             Logger.LogVerbose($"Loading addon manifest for {mod.ModHelper.Manifest.Name}");
 
-            var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>(file);
+            var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>(file, false);
 
             if (addonConfig.achievements != null)
             {
@@ -706,7 +706,7 @@ namespace NewHorizons
             NewHorizonsBody body = null;
             try
             {
-                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath);
+                var config = mod.ModHelper.Storage.Load<PlanetConfig>(relativePath, false);
                 if (config == null)
                 {
                     Logger.LogError($"Couldn't load {relativePath}. Is your Json formatted correctly?");
@@ -719,7 +719,7 @@ namespace NewHorizons
                 if (!SystemDict.ContainsKey(config.starSystem))
                 {
                     // Since we didn't load it earlier there shouldn't be a star system config
-                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>($"systems/{config.starSystem}.json");
+                    var starSystemConfig = mod.ModHelper.Storage.Load<StarSystemConfig>(Path.Combine("systems", config.starSystem + ".json"), false);
                     if (starSystemConfig == null) starSystemConfig = new StarSystemConfig();
                     else Logger.LogWarning($"Loaded system config for {config.starSystem}. Why wasn't this loaded earlier?");
 


### PR DESCRIPTION
this turns off owml's backslash "fixer"
![image](https://user-images.githubusercontent.com/26337121/196365766-5ce2978a-6c71-4e83-be08-a5e7dca99430.png)

apparently, the backslash fixer was implemented for path-character reasons. 
unfortunately, it happens to break all escape characters, such as The Vision's https://github.com/Outer-Wilds-New-Horizons/new-horizons/issues/424#issuecomment-1281856989

it being disabled doesn't seem to break anything.
further testing on linux is probably needed. obv i cant do that testing.

