### PR TITLE
fix #428: NH ship log facts are required for the Archaeologist achievement

### DIFF
--- a/NewHorizons/Patches/ShipLogPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches.cs
@@ -97,7 +97,7 @@ namespace NewHorizons.Patches
         {
             foreach (KeyValuePair<string, ShipLogFact> keyValuePair in __instance._factDict)
             {
-                if (ShipLogHandler.IsVanillaAstroID(__instance.GetEntry(keyValuePair.Value.GetEntryID()).GetAstroObjectID()) && !keyValuePair.Value.IsRumor() && !keyValuePair.Value.IsRevealed() && !keyValuePair.Key.Equals("TH_VILLAGE_X3") && !keyValuePair.Key.Equals("GD_GABBRO_ISLAND_X1") && __instance.GetEntry(keyValuePair.Value.GetEntryID()).GetCuriosityName() != CuriosityName.InvisiblePlanet)
+                if (!ShipLogHandler.IsModdedFact(keyValuePair.Key) && !keyValuePair.Value.IsRumor() && !keyValuePair.Value.IsRevealed() && !keyValuePair.Key.Equals("TH_VILLAGE_X3") && !keyValuePair.Key.Equals("GD_GABBRO_ISLAND_X1") && __instance.GetEntry(keyValuePair.Value.GetEntryID()).GetCuriosityName() != CuriosityName.InvisiblePlanet)
                 {
                     return false;
                 }


### PR DESCRIPTION
## Bug fixes
- Fix NH ship log facts of vanilla bodies required for the Archaeologist achievement #428 

It turns out there is already a patch for this, but it was only excluding facts from entries of NH astro bodies but not NH facts of vanilla bodies.
