### PR TITLE
docs: add cli tool section

### DIFF
--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -46,7 +46,7 @@ This section outlines how to install and use the nh-translation-helper.
 
 ## Installation
 
-To get started, head over to the [repo for the tool](https://github.com/96-38/nh-translation-helper) and prepare the requirements:
+To get started, head over to the [repo for the tool](https://github.com/96-38/nh-translation-helper){ target="_blank" } and prepare the requirements:
 
 - Install [Node.js](https://nodejs.org/) >= 12.0.0
     - Install the LTS version.

--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -48,7 +48,7 @@ This section outlines how to install and use the nh-translation-helper.
 
 To get started, head over to the [repo for the tool](https://github.com/96-38/nh-translation-helper){ target="_blank" } and prepare the requirements:
 
-- Install [Node.js](https://nodejs.org/) >= 12.0.0
+- Install [Node.js](https://nodejs.org/){ target="_blank" } >= 12.0.0
     - Install the LTS version.
 - Get [DeepL API](https://www.deepl.com/docs-api) Key (Free or Pro)
     - Sign up [here](https://www.deepl.com/pro#developer)

--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -32,3 +32,69 @@ Here's an example, for `russian.json`:
     }
 }
 ```
+
+# CLI Tool
+
+Are you tired of manually translating JSON? Do you want an automatic translator? Well then the [nh-translation-helper](https://www.npmjs.com/package/nh-translation-helper) may be for you!
+
+This tool has the following features:
+
+- Extract text from XML files and create english.json as the translation source.
+- Translate english.json to create a json file for another language.
+
+This section outlines how to install and use the nh-translation-helper.
+
+## Installation
+
+To get started, head over to the [repo for the tool](https://github.com/96-38/nh-translation-helper) and prepare the requirements:
+
+- Install [Node.js](https://nodejs.org/) >= 12.0.0
+    - Install the LTS version.
+- Get [DeepL API](https://www.deepl.com/docs-api) Key (Free or Pro)
+    - Sign up [here](https://www.deepl.com/pro#developer)
+
+When you are ready, execute the following command in a terminal or command prompt:
+
+```bash
+npm i -g nh-translation-helper
+```
+
+Now your installation is complete!
+
+You can use the tool by executing the following command in a terminal or command prompt:
+
+```bash
+nh-translation-helper
+```
+
+## Generating a english.json from XML
+
+Select `Generate english.json from XML files` and enter the path of your project folder.
+
+You are done! a english.json has been generated in "*your_project_root*/translations/".
+
+## Translating english.json to another language
+
+Select `Translate JSON (DeepL API key required)` and enter the path of your project folder. ( Note: **Not** the path to the "translations" folder. )
+
+Select the source and target languages.
+
+You are done! a translated json file has been generated in "*your_project_root*/translations/".
+
+Please enter the DeepL API key for the first time only. The API key will be saved on your PC.
+
+## Note
+
+- Not supported extracting UIDictionary and AchievementTranslations
+    - It is difficult to parse these automatically, and the number of words is small that it would be better to add them by MOD developers manually for better results.
+    - Translating UIDictionary and AchievementTranslations is supported.
+
+- Not supported translation into Korean
+    - Translation is provided by the DeepL API, so it is not possible to translate into languages that are not supported by DeepL.
+
+- The generated translations are "**not**" perfect
+    - It is a machine translation though DeepL. The translations on DeepL are known to be too casual or to abbreviate some sentences.
+    - It will need to be manually corrected to make it a good translation. However, this tool allows you to prototype and is more efficient than starting from scratch. Also, the CDATA tag has been removed from the translated text and must be added manually.
+
+- Parsing errors may occur when trying to translate manually created JSON files
+    - In many cases, this is due to a specific comment in the JSON. Please remove the comments and try again.

--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -50,7 +50,7 @@ To get started, head over to the [repo for the tool](https://github.com/96-38/nh
 
 - Install [Node.js](https://nodejs.org/){ target="_blank" } >= 12.0.0
     - Install the LTS version.
-- Get [DeepL API](https://www.deepl.com/docs-api) Key (Free or Pro)
+- Get [DeepL API](https://www.deepl.com/docs-api){ target="_blank" } Key (Free or Pro)
     - Sign up [here](https://www.deepl.com/pro#developer)
 
 When you are ready, execute the following command in a terminal or command prompt:

--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -35,7 +35,7 @@ Here's an example, for `russian.json`:
 
 # CLI Tool
 
-Are you tired of manually translating JSON? Do you want an automatic translator? Well then the [nh-translation-helper](https://www.npmjs.com/package/nh-translation-helper) may be for you!
+Are you tired of manually translating JSON? Do you want an automatic translator? Well then the [nh-translation-helper](https://www.npmjs.com/package/nh-translation-helper){ target="_blank" } may be for you!
 
 This tool has the following features:
 

--- a/docs/content/pages/tutorials/translation.md
+++ b/docs/content/pages/tutorials/translation.md
@@ -51,7 +51,7 @@ To get started, head over to the [repo for the tool](https://github.com/96-38/nh
 - Install [Node.js](https://nodejs.org/){ target="_blank" } >= 12.0.0
     - Install the LTS version.
 - Get [DeepL API](https://www.deepl.com/docs-api){ target="_blank" } Key (Free or Pro)
-    - Sign up [here](https://www.deepl.com/pro#developer)
+    - Sign up [here](https://www.deepl.com/pro#developer){ target="_blank" }
 
 When you are ready, execute the following command in a terminal or command prompt:
 


### PR DESCRIPTION
<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- Added a CLI Tool section to the Translations page of the documentation.
I created with reference to the Config Editor page. However, I am not a native English speaker, so please let me know if there are any sentences that are grammatically incorrect.
<img width="900" alt="CleanShot 2022-10-30 at 10 07 16@2x" src="https://user-images.githubusercontent.com/48713768/198858132-f00aad93-8abf-446d-b9b3-2547230a139f.png">
