### PR TITLE
Detail rotation fix

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -132,7 +132,7 @@ namespace NewHorizons.Builder.Props
                 // Apply the rotation after aligning it with normal
                 var up = (prop.transform.position - go.transform.position).normalized;
                 prop.transform.rotation = Quaternion.FromToRotation(Vector3.up, up);
-                prop.transform.rotation *= rot;
+                prop.transform.rotation = rot * prop.transform.rotation;
             }
             else
             {

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -132,7 +132,7 @@ namespace NewHorizons.Builder.Props
                 // Apply the rotation after aligning it with normal
                 var up = (prop.transform.position - go.transform.position).normalized;
                 prop.transform.rotation = Quaternion.FromToRotation(Vector3.up, up);
-                prop.transform.rotation = rot * prop.transform.rotation;
+                prop.transform.rotation *= rot;
             }
             else
             {

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -130,7 +130,7 @@ namespace NewHorizons.Builder.Props
             if (detail.alignToNormal)
             {
                 // Apply the rotation after aligning it with normal
-                var up = go.transform.InverseTransformPoint(prop.transform.position).normalized;
+                var up = (prop.transform.position - go.transform.position).normalized;
                 prop.transform.rotation = Quaternion.FromToRotation(Vector3.up, up);
                 prop.transform.rotation *= rot;
             }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -221,21 +221,21 @@
       "properties": {
         "r": {
           "type": "integer",
-          "description": "The red component of this colour",
+          "description": "The red component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0
         },
         "g": {
           "type": "integer",
-          "description": "The green component of this colour",
+          "description": "The green component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0
         },
         "b": {
           "type": "integer",
-          "description": "The blue component of this colour",
+          "description": "The blue component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0

--- a/NewHorizons/Schemas/star_system_schema.json
+++ b/NewHorizons/Schemas/star_system_schema.json
@@ -263,21 +263,21 @@
       "properties": {
         "r": {
           "type": "integer",
-          "description": "The red component of this colour",
+          "description": "The red component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0
         },
         "g": {
           "type": "integer",
-          "description": "The green component of this colour",
+          "description": "The green component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0
         },
         "b": {
           "type": "integer",
-          "description": "The blue component of this colour",
+          "description": "The blue component of this colour from 0-255, higher values will make the colour glow if applicable.",
           "format": "int32",
           "maximum": 2147483647.0,
           "minimum": 0.0

--- a/NewHorizons/Utility/DebugMenu/DebugMenuNomaiText.cs
+++ b/NewHorizons/Utility/DebugMenu/DebugMenuNomaiText.cs
@@ -225,7 +225,7 @@ namespace NewHorizons.Utility.DebugMenu
                                     else if (conversationMeta.conversationGo != null)
                                     {
                                         conversationMeta.conversationGo.transform.localPosition = data.pos;
-                                        DebugPropPlacer.SetGameObjectRotation(conversationMeta.conversationGo, data, _dnp.gameObject.transform.position);
+                                        conversationMeta.conversationGo.transform.rotation = data.rot;
                                         
                                         conversationMeta.conversation.position = conversationMeta.conversationGo.transform.localPosition;
                                         conversationMeta.conversation.rotation = conversationMeta.conversationGo.transform.localEulerAngles;

--- a/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
+++ b/NewHorizons/Utility/DebugUtilities/DebugPropPlacer.cs
@@ -106,7 +106,7 @@ namespace NewHorizons.Utility.DebugUtilities
         internal void PlaceObject()
         {
             DebugRaycastData data = _rc.Raycast();
-            PlaceObject(data, this.gameObject.transform.position);
+            PlaceObject(data);
 
             if (!hasAddedCurrentObjectToRecentsList)
             {
@@ -119,7 +119,7 @@ namespace NewHorizons.Utility.DebugUtilities
             }
         }
 
-        public void PlaceObject(DebugRaycastData data, Vector3 playerAbsolutePosition)
+        public void PlaceObject(DebugRaycastData data)
         {
             // TODO: implement sectors
             // if this hits a sector, store that sector and add a config file option for it
@@ -149,14 +149,12 @@ namespace NewHorizons.Utility.DebugUtilities
                 var detailInfo = new PropModule.DetailInfo()
                 {
                     position = data.pos,
-                    rotation = data.norm,
+                    rotation = data.rot.eulerAngles,
                 };
                 var prop = DetailBuilder.Make(planetGO, sector, prefab, detailInfo);
 
                 var body = data.hitBodyGameObject.GetComponent<AstroObject>();
                 if (body != null) RegisterProp(body, prop);
-
-                SetGameObjectRotation(prop, data, playerAbsolutePosition);
             }
             catch
             {
@@ -164,28 +162,7 @@ namespace NewHorizons.Utility.DebugUtilities
             }
         }
 
-        public static void SetGameObjectRotation(GameObject prop, DebugRaycastData data, Vector3 playerAbsolutePosition)
-        {
-            // align with surface normal
-            Vector3 alignToSurface = (Quaternion.LookRotation(data.norm) * Quaternion.FromToRotation(Vector3.up, Vector3.forward)).eulerAngles;
-            prop.transform.localEulerAngles = alignToSurface;
 
-            // rotate facing dir towards player
-            GameObject g = new GameObject("DebugProp");
-            g.transform.parent = prop.transform.parent;
-            g.transform.localPosition = prop.transform.localPosition;
-            g.transform.localRotation = prop.transform.localRotation;
-
-            prop.transform.parent = g.transform;
-
-            var dirTowardsPlayer = prop.transform.parent.transform.InverseTransformPoint(playerAbsolutePosition) - prop.transform.localPosition;
-            dirTowardsPlayer.y = 0;
-            float rotation = Quaternion.LookRotation(dirTowardsPlayer).eulerAngles.y;
-            prop.transform.localEulerAngles = new Vector3(0, rotation, 0);
-
-            prop.transform.parent = g.transform.parent;
-            GameObject.Destroy(g);
-        }
 
         public static string GetAstroObjectName(string bodyName)
         {

--- a/NewHorizons/Utility/DebugUtilities/DebugRaycastData.cs
+++ b/NewHorizons/Utility/DebugUtilities/DebugRaycastData.cs
@@ -12,6 +12,7 @@ namespace NewHorizons.Utility.DebugUtilities
         public bool hit;
         public Vector3 pos;
         public Vector3 norm;
+        public Quaternion rot;
         public DebugRaycastPlane plane;
 
         public string colliderPath;

--- a/NewHorizons/Utility/MColor.cs
+++ b/NewHorizons/Utility/MColor.cs
@@ -15,19 +15,19 @@ namespace NewHorizons.Utility
         }
 
         /// <summary>
-        /// The red component of this colour
+        /// The red component of this colour from 0-255, higher values will make the colour glow if applicable.
         /// </summary>
         [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)] 
         public int r;
 
         /// <summary>
-        /// The green component of this colour
+        /// The green component of this colour from 0-255, higher values will make the colour glow if applicable.
         /// </summary>
         [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)] 
         public int g;
-        
+
         /// <summary>
-        /// The blue component of this colour
+        /// The blue component of this colour from 0-255, higher values will make the colour glow if applicable.
         /// </summary>
         [System.ComponentModel.DataAnnotations.Range(0, int.MaxValue)] 
         public int b;

--- a/NewHorizons/Utility/NewHorizonExtensions.cs
+++ b/NewHorizons/Utility/NewHorizonExtensions.cs
@@ -211,6 +211,12 @@ namespace NewHorizons.Utility
         }
 
 
+        /// <summary>
+        /// Transform rotation from Local Space to World Space
+        /// </summary>
+        /// <param name="transform"></param>
+        /// <param name="localRotation"></param>
+        /// <returns></returns>
         public static Quaternion TransformRotation(this Transform transform, Quaternion localRotation)
         {
             return transform.rotation * localRotation;


### PR DESCRIPTION
## Improvements
- Debug Raycast now writes the rotation value to use to have the placed object aligned to the surface its on and facing towards the player.

## Bug fixes
- `alignToNormal` now no longer breaks on vanilla planets.
