### PR TITLE
Update Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
         path: .\NewHorizons\Schemas
 
     - name: Verify Changed Schemas
-      uses: tj-actions/verify-changed-files@v34
+      uses: tj-actions/verify-changed-files@v12
       id: changed_files
       with:
         files: NewHorizons/Schemas/**

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
         path: .\NewHorizons\Schemas
 
     - name: Verify Changed Schemas
-      uses: tj-actions/verify-changed-files@v12
+      uses: tj-actions/verify-changed-files@v34
       id: changed_files
       with:
         files: NewHorizons/Schemas/**

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -23,5 +23,4 @@ jobs:
     uses: './.github/workflows/update_schemas.yml'
     with:
       artifact_name: NewHorizons-Schemas-Debug
-    secrets:
-      SCHEMAS_TOKEN: ${{ secrets.SCHEMAS_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -23,3 +23,5 @@ jobs:
     uses: './.github/workflows/update_schemas.yml'
     with:
       artifact_name: NewHorizons-Schemas-Debug
+    secrets:
+      SCHEMAS_TOKEN: ${{ secrets.SCHEMAS_TOKEN }}

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -34,6 +34,8 @@ jobs:
     uses: ./.github/workflows/update_schemas.yml
     with:
       artifact_name: NewHorizons-Schemas-Release
+    secrets:
+      SCHEMAS_TOKEN: ${{ secrets.SCHEMAS_TOKEN }}
   Update_Docs:
     name: 'Update Docs'
     needs: Build

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -34,8 +34,7 @@ jobs:
     uses: ./.github/workflows/update_schemas.yml
     with:
       artifact_name: NewHorizons-Schemas-Release
-    secrets:
-      SCHEMAS_TOKEN: ${{ secrets.SCHEMAS_TOKEN }}
+    secrets: inherit
   Update_Docs:
     name: 'Update Docs'
     needs: Build

--- a/.github/workflows/update_schemas.yml
+++ b/.github/workflows/update_schemas.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SCHEMAS_TOKEN }}
 
       - name: Download Artifact
         uses: actions/download-artifact@v3
@@ -28,13 +30,13 @@ jobs:
           
       - name: Commit Schemas
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --local user.email "bwc9876@gmail.com"
+          git config --local user.name "Ben C"
           git add NewHorizons/Schemas/**
           git commit -m "Updated Schemas"
           
       - name: Push Schemas
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.SCHEMAS_TOKEN }}
           branch: ${{ github.ref }}

--- a/NewHorizons/External/Configs/PlanetConfig.cs
+++ b/NewHorizons/External/Configs/PlanetConfig.cs
@@ -11,7 +11,7 @@ using Logger = NewHorizons.Utility.Logger;
 namespace NewHorizons.External.Configs
 {
     /// <summary>
-    /// Describes a body to generate
+    /// Describes a celestial body to generate
     /// </summary>
     [JsonObject(Title = "Celestial Body")]
     public class PlanetConfig

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Celestial Body Schema",
   "type": "object",
-  "description": "Describes a body to generate",
+  "description": "Describes a celestial body to generate",
   "additionalProperties": false,
   "required": [
     "name"


### PR DESCRIPTION
Bc of branch protection rules the default actions token can't push to `main`, which screws up a lot. So this PR uses a PAT i generated to push schemas instead bc I can bypass those restrictions.