### PR TITLE
Add "reveal for" option to enter reveal volumes

### DIFF
--- a/NewHorizons/Builder/ShipLog/RevealBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RevealBuilder.cs
@@ -88,6 +88,7 @@ namespace NewHorizons.Builder.ShipLog
                         break;
                     case VolumesModule.RevealVolumeInfo.EnterType.Both:
                     default:
+                        // if you want both player and probe to able to trigger the thing you have to set both player and probe to false. setting both to true will make nothing trigger it
                         factRevealVolume._player = false;
                         factRevealVolume._probe = false;
                         break;

--- a/NewHorizons/Builder/ShipLog/RevealBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RevealBuilder.cs
@@ -76,6 +76,22 @@ namespace NewHorizons.Builder.ShipLog
             {
                 var factRevealVolume = go.AddComponent<ShipLogFactListTriggerVolume>();
                 factRevealVolume._factIDs = info.reveals;
+                switch (info.revealFor)
+                {
+                    case VolumesModule.RevealVolumeInfo.EnterType.Player:
+                        factRevealVolume._player = true;
+                        factRevealVolume._probe = false;
+                        break;
+                    case VolumesModule.RevealVolumeInfo.EnterType.Probe:
+                        factRevealVolume._player = false;
+                        factRevealVolume._probe = true;
+                        break;
+                    case VolumesModule.RevealVolumeInfo.EnterType.Both:
+                    default:
+                        factRevealVolume._player = false;
+                        factRevealVolume._probe = false;
+                        break;
+                }
             }
 
             if (!string.IsNullOrEmpty(info.achievementID))

--- a/NewHorizons/External/Modules/VolumesModule.cs
+++ b/NewHorizons/External/Modules/VolumesModule.cs
@@ -109,6 +109,16 @@ namespace NewHorizons.External.Modules
                 [EnumMember(Value = @"snapshot")] Snapshot = 2
             }
 
+            [JsonConverter(typeof(StringEnumConverter))]
+            public enum EnterType
+            {
+                [EnumMember(Value = @"both")] Both = 0,
+
+                [EnumMember(Value = @"player")] Player = 1,
+
+                [EnumMember(Value = @"probe")] Probe = 2
+            }
+
             /// <summary>
             /// The max view angle (in degrees) the player can see the volume with to unlock the fact (`observe` only)
             /// </summary>
@@ -123,6 +133,11 @@ namespace NewHorizons.External.Modules
             /// What needs to be done to the volume to unlock the facts
             /// </summary>
             [DefaultValue("enter")] public RevealVolumeType revealOn = RevealVolumeType.Enter;
+
+            /// <summary>
+            /// What needs to be enter the volume to unlock the facts (`enter` only)
+            /// </summary>
+            [DefaultValue("both")] public EnterType revealFor = EnterType.Both;
 
             /// <summary>
             /// A list of facts to reveal

--- a/NewHorizons/External/Modules/VolumesModule.cs
+++ b/NewHorizons/External/Modules/VolumesModule.cs
@@ -135,7 +135,7 @@ namespace NewHorizons.External.Modules
             [DefaultValue("enter")] public RevealVolumeType revealOn = RevealVolumeType.Enter;
 
             /// <summary>
-            /// What needs to enter the volume to unlock the facts (`enter` only)
+            /// What can enter the volume to unlock the facts (`enter` only)
             /// </summary>
             [DefaultValue("both")] public EnterType revealFor = EnterType.Both;
 

--- a/NewHorizons/External/Modules/VolumesModule.cs
+++ b/NewHorizons/External/Modules/VolumesModule.cs
@@ -135,7 +135,7 @@ namespace NewHorizons.External.Modules
             [DefaultValue("enter")] public RevealVolumeType revealOn = RevealVolumeType.Enter;
 
             /// <summary>
-            /// What needs to be enter the volume to unlock the facts (`enter` only)
+            /// What needs to enter the volume to unlock the facts (`enter` only)
             /// </summary>
             [DefaultValue("both")] public EnterType revealFor = EnterType.Both;
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2839,7 +2839,7 @@
           "$ref": "#/definitions/RevealVolumeType"
         },
         "revealFor": {
-          "description": "What needs to be enter the volume to unlock the facts (`enter` only)",
+          "description": "What needs to enter the volume to unlock the facts (`enter` only)",
           "default": "both",
           "$ref": "#/definitions/EnterType"
         },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2839,7 +2839,7 @@
           "$ref": "#/definitions/RevealVolumeType"
         },
         "revealFor": {
-          "description": "What needs to enter the volume to unlock the facts (`enter` only)",
+          "description": "What can enter the volume to unlock the facts (`enter` only)",
           "default": "both",
           "$ref": "#/definitions/EnterType"
         },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2838,6 +2838,11 @@
           "default": "enter",
           "$ref": "#/definitions/RevealVolumeType"
         },
+        "revealFor": {
+          "description": "What needs to be enter the volume to unlock the facts (`enter` only)",
+          "default": "both",
+          "$ref": "#/definitions/EnterType"
+        },
         "reveals": {
           "type": "array",
           "description": "A list of facts to reveal",
@@ -2863,6 +2868,20 @@
         "enter",
         "observe",
         "snapshot"
+      ]
+    },
+    "EnterType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Both",
+        "Player",
+        "Probe"
+      ],
+      "enum": [
+        "both",
+        "player",
+        "probe"
       ]
     },
     "PriorityVolumeInfo": {


### PR DESCRIPTION
Can now choose whether the player, scout, or both can trigger the enter reveal volume.

I have not tested this yet.