### PR TITLE
Add vinePrefab option

### DIFF
--- a/NewHorizons/External/Modules/BrambleModule.cs
+++ b/NewHorizons/External/Modules/BrambleModule.cs
@@ -1,15 +1,30 @@
 using NewHorizons.Utility;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Runtime.Serialization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace NewHorizons.External.Modules
 {
-    
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum VinePrefabType
+    {
+        [EnumMember(Value = @"none")] None = 0,
+
+        [EnumMember(Value = @"hub")] Hub = 1,
+
+        [EnumMember(Value = @"cluster")] Cluster = 2,
+
+        [EnumMember(Value = @"smallNest")] SmallNest = 3,
+
+        [EnumMember(Value = @"exitOnly")] ExitOnly = 4
+    }
+
     [JsonObject]
     public class BrambleModule
     {
@@ -50,10 +65,10 @@ namespace NewHorizons.External.Modules
             [DefaultValue(750f)] public float radius = 750f;
 
             /// <summary>
-            /// Whether this dimensions has vines.
-            /// Set to false if you want to create your own vines.
+            /// The dimension the vines will be copied from.
+            /// Only a handful are available due to batched colliders.
             /// </summary>
-            [DefaultValue(true)] public bool hasVines = true;
+            [DefaultValue("hub")] public VinePrefabType vinePrefab = VinePrefabType.Hub;
 
             /// <summary>
             /// An array of integers from 0-5. By default, all entrances are allowed. To force this dimension to warp players in from only one point (like the anglerfish nest dimension in the base game) set this value to [3], [5], or similar. Values of 0-5 only.

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -575,10 +575,10 @@
           "format": "float",
           "default": 750.0
         },
-        "hasVines": {
-          "type": "boolean",
-          "description": "Whether this dimensions has vines.\nSet to false if you want to create your own vines.",
-          "default": true
+        "vinePrefab": {
+          "description": "The dimension the vines will be copied from.\nOnly a handful are available due to batched colliders.",
+          "default": "hub",
+          "$ref": "#/definitions/VinePrefabType"
         },
         "allowedEntrances": {
           "type": "array",
@@ -589,6 +589,24 @@
           }
         }
       }
+    },
+    "VinePrefabType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "None",
+        "Hub",
+        "Cluster",
+        "SmallNest",
+        "ExitOnly"
+      ],
+      "enum": [
+        "none",
+        "hub",
+        "cluster",
+        "smallNest",
+        "exitOnly"
+      ]
     },
     "BrambleNodeInfo": {
       "type": "object",


### PR DESCRIPTION
Replaces `hasVines` with `vinePrefab` so you can use various dimension vines for variety without having to deal with custom vines