### PR TITLE
Fix some time loop bugs

### DIFF
--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -58,6 +58,7 @@ namespace NewHorizons
 
         public string DefaultStarSystem => SystemDict.ContainsKey(_defaultSystemOverride) ? _defaultSystemOverride : _defaultStarSystem;
         public string CurrentStarSystem => _currentStarSystem;
+        public bool TimeLoopEnabled => SystemDict[CurrentStarSystem]?.Config?.enableTimeLoop ?? true;
         public bool IsWarpingFromShip { get; private set; } = false;
         public bool IsWarpingFromVessel { get; private set; } = false;
         public bool IsWarpingBackToEye { get; internal set; } = false;

--- a/NewHorizons/Patches/TimeLoopPatches.cs
+++ b/NewHorizons/Patches/TimeLoopPatches.cs
@@ -46,5 +46,12 @@ namespace NewHorizons.Patches
         [HarmonyPrefix]
         [HarmonyPatch(typeof(GlobalMusicController), nameof(GlobalMusicController.UpdateEndTimesMusic))]
         public static bool GlobalMusicController_UpdateEndTimesMusic() => Main.Instance.TimeLoopEnabled;
+
+        /// <summary>
+        /// Disables supernova trigger
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Update))]
+        public static bool TimeLoop_Update() => Main.Instance.TimeLoopEnabled;
     }
 }

--- a/NewHorizons/Patches/TimeLoopPatches.cs
+++ b/NewHorizons/Patches/TimeLoopPatches.cs
@@ -1,0 +1,50 @@
+using HarmonyLib;
+
+namespace NewHorizons.Patches
+{
+    [HarmonyPatch]
+    public static class TimeLoopPatches
+    {
+        /// <summary>
+        /// Disables starfield updates
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(StarfieldController), nameof(StarfieldController.Update))]
+        public static bool StarfieldController_Update() => Main.Instance.TimeLoopEnabled;
+
+        /// <summary>
+        /// Disables interloper destruction
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(TempCometCollisionFix), nameof(TempCometCollisionFix.Update))]
+        public static bool TempCometCollisionFix_Update() => Main.Instance.TimeLoopEnabled;
+
+        /// <summary>
+        /// Disables sun logic
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(SunController), nameof(SunController.Update))]
+        public static bool SunController_Update(SunController __instance) => Main.Instance.TimeLoopEnabled && __instance.isActiveAndEnabled;
+
+        /// <summary>
+        /// Disables sun expansion
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(SunController), nameof(SunController.UpdateScale))]
+        public static bool SunController_UpdateScale(SunController __instance) => Main.Instance.TimeLoopEnabled && __instance.isActiveAndEnabled;
+
+        /// <summary>
+        /// Disables sun collapse SFX
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(SunController), nameof(SunController.OnTriggerSupernova))]
+        public static bool SunController_OnTriggerSupernova(SunController __instance) => Main.Instance.TimeLoopEnabled && __instance.isActiveAndEnabled;
+
+        /// <summary>
+        /// Disables end times music
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(GlobalMusicController), nameof(GlobalMusicController.UpdateEndTimesMusic))]
+        public static bool GlobalMusicController_UpdateEndTimesMusic() => Main.Instance.TimeLoopEnabled;
+    }
+}


### PR DESCRIPTION
Should fix a few bugs from #407 and more
- Background stars no longer go supernova when time loop is disabled
- Sun no longer does supernova effects while disabled
- Sun will not expand into red giant when time loop is disabled
- Interloper no longer disappears when time loop is disabled
- End times music will not play when time loop is disabled
- Time loop component no longer triggers supernova when time loop is disabled