### PR TITLE
fix shader replacement mistake

### DIFF
--- a/NewHorizons/Utility/AssetBundleUtilities.cs
+++ b/NewHorizons/Utility/AssetBundleUtilities.cs
@@ -88,6 +88,10 @@ namespace NewHorizons.Utility
                         material.SetOverrideTag("RenderType", renderType);
                         material.renderQueue = renderQueue;
                     }
+                    else
+                    {
+                        material.shader = replacementShader;
+                    }
                 }
             }
         }

--- a/NewHorizons/Utility/AssetBundleUtilities.cs
+++ b/NewHorizons/Utility/AssetBundleUtilities.cs
@@ -80,11 +80,14 @@ namespace NewHorizons.Utility
 
                     // preserve override tag and render queue (for Standard shader)
                     // keywords and properties are already preserved
-                    var renderType = material.GetTag("RenderType", false);
-                    var renderQueue = material.renderQueue;
-                    material.shader = replacementShader;
-                    material.SetOverrideTag("RenderType", renderType);
-                    material.renderQueue = renderQueue;
+                    if (material.renderQueue != material.shader.renderQueue)
+                    {
+                        var renderType = material.GetTag("RenderType", false);
+                        var renderQueue = material.renderQueue;
+                        material.shader = replacementShader;
+                        material.SetOverrideTag("RenderType", renderType);
+                        material.renderQueue = renderQueue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
when i fixed it i forgot about dummy shaders (which dont have the proper render queue set)
so this makes it only preserve stuff when the material queue is different from the shader queue (ie we want to preserve that difference)