### PR TITLE
Manual bramble recursion fix

### DIFF
--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -365,6 +365,15 @@ namespace NewHorizons.Builder.Props
             var success = PairEntrance(innerFogWarpVolume, config.linksTo);
             if (!success) RecordUnpairedNode(innerFogWarpVolume, config.linksTo);
 
+            if (config.preventRecursionCrash)
+            {
+                Delay.FireOnNextUpdate(() =>
+                {
+                    var destination = GetOuterFogWarpVolumeFromAstroObject(AstroObjectLocator.GetAstroObject(config.linksTo).gameObject);
+                    if (destination != null) destination._senderWarps.Remove(innerFogWarpVolume);
+                });
+            }
+
             // Cleanup for dimension exits
             if (config.name != null)
             {

--- a/NewHorizons/External/Modules/BrambleModule.cs
+++ b/NewHorizons/External/Modules/BrambleModule.cs
@@ -134,6 +134,12 @@ namespace NewHorizons.External.Modules
             /// </summary>
             public int[] possibleExits;
 
+            /// <summary>
+            /// If your game hard crashes upon entering bramble, it's most likely because you have indirectly recursive dimensions, i.e. one leads to another that leads back to the first one.
+            /// Set this to true for one of the nodes in the recursion to fix this, at the cost of it no longer showing markers for the scout, ship, etc.
+            /// </summary>
+            [DefaultValue(false)] public bool preventRecursionCrash = false;
+
             #region Obsolete
 
             [Obsolete("farFogTint is deprecated, please use fogTint instead")]

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -661,6 +661,11 @@
             "type": "integer",
             "format": "int32"
           }
+        },
+        "preventRecursionCrash": {
+          "type": "boolean",
+          "description": "If your game hard crashes upon entering bramble, it's most likely because you have indirectly recursive dimensions, i.e. one leads to another that leads back to the first one.\nSet this to true for one of the nodes in the recursion to fix this, at the cost of it no longer showing markers for the scout, ship, etc.",
+          "default": false
         }
       }
     },


### PR DESCRIPTION
Option to manually remove a sender warp for cases where the recursion scanner fails.