### PR TITLE
More remote dialogue stuff

### DIFF
--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -80,8 +80,10 @@ namespace NewHorizons.Builder.Props
                     priority = 1,
                     dialogue = dialogue,
                     prereqConditionType = RemoteDialogueTrigger.MultiConditionType.AND,
-                    prereqConditions = info.remoteTriggerPrereqConditions ?? new string[]{ },
-                    onTriggerEnterConditions = info.remoteTriggerOnEnterConditions ?? new string[]{ }
+                    // Base game never uses more than one condition anyone so we'll keep it simple
+                    prereqConditions = string.IsNullOrEmpty(info.remoteTriggerPrereqCondition) ? new string[]{ } : new string[] { info.remoteTriggerPrereqCondition },
+                    // Just set your enter conditions in XML instead of complicating it with this
+                    onTriggerEnterConditions = new string[]{ }
                 }
             };
             remoteDialogueTrigger._activatedDialogues = new bool[1];

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -80,8 +80,8 @@ namespace NewHorizons.Builder.Props
                     priority = 1,
                     dialogue = dialogue,
                     prereqConditionType = RemoteDialogueTrigger.MultiConditionType.AND,
-                    prereqConditions = new string[]{ },
-                    onTriggerEnterConditions = new string[]{ }
+                    prereqConditions = info.remoteTriggerPrereqConditions ?? new string[]{ },
+                    onTriggerEnterConditions = info.remoteTriggerOnEnterConditions ?? new string[]{ }
                 }
             };
             remoteDialogueTrigger._activatedDialogues = new bool[1];

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -509,6 +509,16 @@ namespace NewHorizons.External.Modules
             public float remoteTriggerRadius;
 
             /// <summary>
+            /// If setting up a remote trigger volume, these conditions must be met for it to trigger
+            /// </summary>
+            public string[] remoteTriggerPrereqConditions;
+
+            /// <summary>
+            /// If setting up a remote trigger volume, but I have no idea what this does at all
+            /// </summary>
+            public string[] remoteTriggerOnEnterConditions;
+
+            /// <summary>
             /// Relative path to the xml file defining the dialogue.
             /// </summary>
             public string xmlFile;

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -509,14 +509,9 @@ namespace NewHorizons.External.Modules
             public float remoteTriggerRadius;
 
             /// <summary>
-            /// If setting up a remote trigger volume, these conditions must be met for it to trigger
+            /// If setting up a remote trigger volume, this conditions must be met for it to trigger. Note: This is a dialogue condition, not a persistent condition.
             /// </summary>
-            public string[] remoteTriggerPrereqConditions;
-
-            /// <summary>
-            /// If setting up a remote trigger volume, but I have no idea what this does at all
-            /// </summary>
-            public string[] remoteTriggerOnEnterConditions;
+            public string remoteTriggerPrereqCondition;
 
             /// <summary>
             /// Relative path to the xml file defining the dialogue.

--- a/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
+++ b/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
@@ -14,18 +14,25 @@ namespace NewHorizons.Patches
         [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
         public static void OnTriggerEnter(RemoteDialogueTrigger __instance)
         {
-            _wasLastDialogueInactive = __instance._activeRemoteDialogue.gameObject.activeInHierarchy;
-            __instance._activeRemoteDialogue.gameObject.SetActive(true);
+            if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue != null)
+            {
+                _wasLastDialogueInactive = __instance._activeRemoteDialogue.gameObject.activeInHierarchy;
+                __instance._activeRemoteDialogue.gameObject.SetActive(true);
+            }
         }
 
         [HarmonyPrefix]
         [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
         public static void OnEndConversation(RemoteDialogueTrigger __instance)
         {
-            if (_wasLastDialogueInactive)
+            if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue != null)
             {
-                __instance._activeRemoteDialogue.gameObject.SetActive(false);
+                if (_wasLastDialogueInactive)
+                {
+                    __instance._activeRemoteDialogue.gameObject.SetActive(false);
+                }
             }
+
             _wasLastDialogueInactive = false;
         }
     }

--- a/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
+++ b/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
@@ -1,4 +1,6 @@
 using HarmonyLib;
+using NewHorizons.Utility;
+using System;
 
 namespace NewHorizons.Patches
 {
@@ -14,10 +16,13 @@ namespace NewHorizons.Patches
         [HarmonyPatch(typeof(RemoteDialogueTrigger), nameof(RemoteDialogueTrigger.OnTriggerEnter))]
         public static void RemoteDialogueTrigger_OnTriggerEnter(RemoteDialogueTrigger __instance)
         {
-            if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue != null)
+            if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue?.gameObject != null)
             {
                 _wasLastDialogueInactive = __instance._activeRemoteDialogue.gameObject.activeInHierarchy;
-                __instance._activeRemoteDialogue.gameObject.SetActive(true);
+                if (!_wasLastDialogueInactive)
+                {
+                    __instance._activeRemoteDialogue.gameObject.SetActive(true);
+                }
             }
         }
 

--- a/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
+++ b/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
@@ -1,0 +1,32 @@
+using HarmonyLib;
+
+namespace NewHorizons.Patches
+{
+    /// <summary>
+    /// Should fix a bug where disabled a CharacterDialogueTree makes its related RemoteDialogueTriggers softlock your game
+    /// </summary>
+    [HarmonyPatch]
+    public static class RemoteDialogueTriggerPatches
+    {
+        private static bool _wasLastDialogueInactive = false;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
+        public static void OnTriggerEnter(RemoteDialogueTrigger __instance)
+        {
+            _wasLastDialogueInactive = __instance._activeRemoteDialogue.gameObject.activeInHierarchy;
+            __instance._activeRemoteDialogue.gameObject.SetActive(true);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
+        public static void OnEndConversation(RemoteDialogueTrigger __instance)
+        {
+            if (_wasLastDialogueInactive)
+            {
+                __instance._activeRemoteDialogue.gameObject.SetActive(false);
+            }
+            _wasLastDialogueInactive = false;
+        }
+    }
+}

--- a/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
+++ b/NewHorizons/Patches/RemoteDialogueTriggerPatches.cs
@@ -11,8 +11,8 @@ namespace NewHorizons.Patches
         private static bool _wasLastDialogueInactive = false;
 
         [HarmonyPostfix]
-        [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
-        public static void OnTriggerEnter(RemoteDialogueTrigger __instance)
+        [HarmonyPatch(typeof(RemoteDialogueTrigger), nameof(RemoteDialogueTrigger.OnTriggerEnter))]
+        public static void RemoteDialogueTrigger_OnTriggerEnter(RemoteDialogueTrigger __instance)
         {
             if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue != null)
             {
@@ -22,8 +22,8 @@ namespace NewHorizons.Patches
         }
 
         [HarmonyPrefix]
-        [HarmonyPatch(typeof(HUDMarker), nameof(HUDMarker.Awake))]
-        public static void OnEndConversation(RemoteDialogueTrigger __instance)
+        [HarmonyPatch(typeof(RemoteDialogueTrigger), nameof(RemoteDialogueTrigger.OnEndConversation))]
+        public static void RemoteDialogueTrigger_OnEndConversation(RemoteDialogueTrigger __instance)
         {
             if (__instance._inRemoteDialogue && __instance._activeRemoteDialogue != null)
             {


### PR DESCRIPTION
## Improvements
- Add `remoteTriggerPrereqCondition` to only show a remote dialogue trigger once a condition has been met.

## Bug fixes
- Stop RemoteDialogueTrigger from softlocking you if you disable its CharacterDialogueTree.
