### PR TITLE
Add volumes for changing star system and triggering credits

### DIFF
--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -203,7 +203,7 @@ namespace NewHorizons.Builder.Body
                     if (hasDestructionVolume) destructionVolumeGO.AddComponent<BlackHoleDestructionVolume>();
                     else if (targetStarSystem != null)
                     {
-                        var wormholeVolume = destructionVolumeGO.AddComponent<ChangeStarSystemVolume>();
+                        var wormholeVolume = destructionVolumeGO.AddComponent<BlackHoleWarpVolume>();
                         wormholeVolume.TargetSolarSystem = targetStarSystem;
                     }
                 }

--- a/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
@@ -1,0 +1,18 @@
+using NewHorizons.Components.Volumes;
+using NewHorizons.External.Modules;
+using UnityEngine;
+
+namespace NewHorizons.Builder.Volumes
+{
+    internal static class ChangeStarSystemVolumeBuilder
+    {
+        public static WarpVolume Make(GameObject planetGO, Sector sector, VolumesModule.ChangeStarSystemVolumeInfo info)
+        {
+            var volume = VolumeBuilder.Make<WarpVolume>(planetGO, sector, info);
+
+            volume.TargetSolarSystem = info.targetStarSystem;
+
+            return volume;
+        }
+    }
+}

--- a/NewHorizons/Builder/Volumes/CreditsVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/CreditsVolumeBuilder.cs
@@ -1,0 +1,18 @@
+using NewHorizons.Components.Volumes;
+using NewHorizons.External.Modules;
+using UnityEngine;
+
+namespace NewHorizons.Builder.Volumes
+{
+    internal static class CreditsVolumeBuilder
+    {
+        public static LoadCreditsVolume Make(GameObject planetGO, Sector sector, VolumesModule.LoadCreditsVolumeInfo info)
+        {
+            var volume = VolumeBuilder.Make<LoadCreditsVolume>(planetGO, sector, info);
+
+            volume.creditsType = info.creditsType;
+
+            return volume;
+        }
+    }
+}

--- a/NewHorizons/Builder/Volumes/VolumesBuildManager.cs
+++ b/NewHorizons/Builder/Volumes/VolumesBuildManager.cs
@@ -192,6 +192,20 @@ namespace NewHorizons.Builder.Volumes
                     VolumeBuilder.Make<LightlessLightSourceVolume>(go, sector, lightSourceVolume);
                 }
             }
+            if (config.Volumes.solarSystemVolume != null)
+            {
+                foreach (var solarSystemVolume in config.Volumes.solarSystemVolume)
+                {
+                    ChangeStarSystemVolumeBuilder.Make(go, sector, solarSystemVolume);
+                }
+            }
+            if (config.Volumes.creditsVolume != null)
+            {
+                foreach (var creditsVolume in config.Volumes.creditsVolume)
+                {
+                    CreditsVolumeBuilder.Make(go, sector, creditsVolume);
+                }
+            }
         }
     }
 }

--- a/NewHorizons/Components/Volumes/BlackHoleWarpVolume.cs
+++ b/NewHorizons/Components/Volumes/BlackHoleWarpVolume.cs
@@ -1,6 +1,6 @@
-﻿namespace NewHorizons.Components.Volumes
+namespace NewHorizons.Components.Volumes
 {
-    public class ChangeStarSystemVolume : BlackHoleDestructionVolume
+    public class BlackHoleWarpVolume : BlackHoleDestructionVolume
     {
         public string TargetSolarSystem { get; set; }
 

--- a/NewHorizons/Components/Volumes/LoadCreditsVolume.cs
+++ b/NewHorizons/Components/Volumes/LoadCreditsVolume.cs
@@ -1,0 +1,35 @@
+using NewHorizons.External.Modules;
+using UnityEngine;
+
+namespace NewHorizons.Components.Volumes
+{
+    internal class LoadCreditsVolume : BaseVolume
+    {
+        public VolumesModule.LoadCreditsVolumeInfo.CreditsType creditsType = VolumesModule.LoadCreditsVolumeInfo.CreditsType.Fast;
+
+        public override void OnTriggerVolumeEntry(GameObject hitObj)
+        {
+            if (hitObj.CompareTag("PlayerDetector"))
+            {
+                switch(creditsType)
+                {
+                    case VolumesModule.LoadCreditsVolumeInfo.CreditsType.Fast:
+                        LoadManager.LoadScene(OWScene.Credits_Fast, LoadManager.FadeType.ToBlack);
+                        break;
+                    case VolumesModule.LoadCreditsVolumeInfo.CreditsType.Final:
+                        LoadManager.LoadScene(OWScene.Credits_Final, LoadManager.FadeType.ToBlack);
+                        break;
+                    case VolumesModule.LoadCreditsVolumeInfo.CreditsType.Kazoo:
+                        TimelineObliterationController.s_hasRealityEnded = true;
+                        LoadManager.LoadScene(OWScene.Credits_Fast, LoadManager.FadeType.ToBlack);
+                        break;
+                }
+            }
+        }
+
+        public override void OnTriggerVolumeExit(GameObject hitObj)
+        {
+
+        }
+    }
+}

--- a/NewHorizons/Components/Volumes/WarpVolume.cs
+++ b/NewHorizons/Components/Volumes/WarpVolume.cs
@@ -1,0 +1,31 @@
+using NewHorizons.External.Modules;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace NewHorizons.Components.Volumes
+{
+    internal class WarpVolume : BaseVolume
+    {
+        public string TargetSolarSystem;
+
+        public override void OnTriggerVolumeEntry(GameObject hitObj)
+        {
+            if (hitObj.CompareTag("PlayerDetector"))
+            {
+                if (Main.Instance.CurrentStarSystem != TargetSolarSystem) // Otherwise it really breaks idk why
+                {
+                    Main.Instance.ChangeCurrentStarSystem(TargetSolarSystem, PlayerState.AtFlightConsole());
+                }
+            }
+        }
+
+        public override void OnTriggerVolumeExit(GameObject hitObj)
+        {
+
+        }
+    }
+}

--- a/NewHorizons/External/Modules/VolumesModule.cs
+++ b/NewHorizons/External/Modules/VolumesModule.cs
@@ -106,6 +106,16 @@ namespace NewHorizons.External.Modules
         /// </summary>
         public PriorityVolumeInfo[] zeroGravityVolumes;
 
+        /// <summary>
+        /// Entering this volume will load a new solar system.
+        /// </summary>
+        public ChangeStarSystemVolumeInfo[] solarSystemVolume;
+
+        /// <summary>
+        /// Enter this volume to be sent to the end credits scene
+        /// </summary>
+        public LoadCreditsVolumeInfo[] creditsVolume;
+
         [JsonObject]
         public class VolumeInfo
         {
@@ -134,6 +144,33 @@ namespace NewHorizons.External.Modules
             /// An optional rename of this volume.
             /// </summary>
             public string rename;
+        }
+
+        [JsonObject]
+        public class ChangeStarSystemVolumeInfo : VolumeInfo
+        {
+            /// <summary>
+            /// The star system that entering this volume will send you to.
+            /// </summary>
+            [DefaultValue("SolarSystem")]
+            public string targetStarSystem;
+        }
+
+        [JsonObject]
+        public class LoadCreditsVolumeInfo : VolumeInfo
+        {
+            [JsonConverter(typeof(StringEnumConverter))]
+            public enum CreditsType
+            {
+                [EnumMember(Value = @"fast")] Fast = 0,
+
+                [EnumMember(Value = @"final")] Final = 1,
+
+                [EnumMember(Value = @"kazoo")] Kazoo = 2
+            }
+
+            [DefaultValue("fast")]
+            public CreditsType creditsType = CreditsType.Fast;
         }
 
         [JsonObject]

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2715,6 +2715,20 @@
           "items": {
             "$ref": "#/definitions/PriorityVolumeInfo"
           }
+        },
+        "solarSystemVolume": {
+          "type": "array",
+          "description": "Entering this volume will load a new solar system.",
+          "items": {
+            "$ref": "#/definitions/ChangeStarSystemVolumeInfo"
+          }
+        },
+        "creditsVolume": {
+          "type": "array",
+          "description": "Enter this volume to be sent to the end credits scene",
+          "items": {
+            "$ref": "#/definitions/LoadCreditsVolumeInfo"
+          }
         }
       }
     },
@@ -3728,6 +3742,85 @@
           "default": 1
         }
       }
+    },
+    "ChangeStarSystemVolumeInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "position": {
+          "description": "The location of this volume. Optional (will default to 0,0,0).",
+          "$ref": "#/definitions/MVector3"
+        },
+        "radius": {
+          "type": "number",
+          "description": "The radius of this volume.",
+          "format": "float",
+          "default": 1.0
+        },
+        "parentPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+        },
+        "isRelativeToParent": {
+          "type": "boolean",
+          "description": "Whether the positional coordinates are relative to parent instead of the root planet object."
+        },
+        "rename": {
+          "type": "string",
+          "description": "An optional rename of this volume."
+        },
+        "targetStarSystem": {
+          "type": "string",
+          "description": "The star system that entering this volume will send you to.",
+          "default": "SolarSystem"
+        }
+      }
+    },
+    "LoadCreditsVolumeInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "position": {
+          "description": "The location of this volume. Optional (will default to 0,0,0).",
+          "$ref": "#/definitions/MVector3"
+        },
+        "radius": {
+          "type": "number",
+          "description": "The radius of this volume.",
+          "format": "float",
+          "default": 1.0
+        },
+        "parentPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+        },
+        "isRelativeToParent": {
+          "type": "boolean",
+          "description": "Whether the positional coordinates are relative to parent instead of the root planet object."
+        },
+        "rename": {
+          "type": "string",
+          "description": "An optional rename of this volume."
+        },
+        "creditsType": {
+          "default": "fast",
+          "$ref": "#/definitions/CreditsType"
+        }
+      }
+    },
+    "CreditsType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Fast",
+        "Final",
+        "Kazoo"
+      ],
+      "enum": [
+        "fast",
+        "final",
+        "kazoo"
+      ]
     }
   },
   "$docs": {

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "owmlVersion": "2.9.0",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_Randomizer" ],


### PR DESCRIPTION
## Minor features
- Added `solarSystemVolume` and `creditsVolume` to the `Volumes` module. Lets you change star system without setting up a black hole, and allows going straight to the fast, final, or kazoo credits scenes.
