### PR TITLE
Fix fog fading occurring for bramble seeds

### DIFF
--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -245,7 +245,7 @@ namespace NewHorizons.Builder.Props
             // Set the seed/node specific scales and other stuff
             if (config.isSeed)
             {
-                innerFogWarpVolume._exitRadius /= 1.8f;
+                //innerFogWarpVolume._exitRadius /= 1.8f;
                 brambleNode.FindChild("PointLight_DB_FogLight").GetComponent<Light>().range *= config.scale;
                 brambleNode.FindChild("Prefab_SeedPunctureVolume (2)").GetComponent<CompoundShape>().enabled = true;
                 fogLight._maxVisibleDistance = float.PositiveInfinity; // Prefab does have working foglight aside from this

--- a/NewHorizons/Patches/BramblePatches.cs
+++ b/NewHorizons/Patches/BramblePatches.cs
@@ -4,23 +4,19 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace NewHorizons.Patches
 {
     [HarmonyPatch]
     public static class BramblePatches
     {
-        //
-        // this file is not great. the real solution to the issues these patches address should be solved by replacing bramble nodes' InnerFogWarpVolume
-        // components with a custom NHInnerFogWarpVolume component, and implement the below functions as overrides in the NHInnerFogWarpVolume class
-        // that would fix the issue of seeds having inappropriate screen fog
-        //
 
         [HarmonyPrefix]
         [HarmonyPatch(typeof(SphericalFogWarpVolume), nameof(SphericalFogWarpVolume.IsProbeOnly))]
         public static bool SphericalFogWarpVolume_IsProbeOnly(SphericalFogWarpVolume __instance, ref bool __result)
         {
-            __result = false;
+            __result = Mathf.Approximately(__instance._exitRadius / __instance._warpRadius, 2f); // Check the ratio between these to determine if seed, instead of just < 10
             return false;
         }
 

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.8.7",
+  "version": "1.9.0",
   "owmlVersion": "2.9.0",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
Instead of always patching false, use the ratio between exit radius and warp radius to determine if it's a seed.