### PR TITLE
Defer singularity linking

### DIFF
--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -32,6 +32,7 @@ namespace NewHorizons.Builder.Body
         public static readonly int Color1 = Shader.PropertyToID("_Color");
 
         private static Dictionary<string, GameObject> _singularitiesByID;
+        private static List<(string, string)> _pairsToLink;
 
         private static Mesh _blackHoleMesh;
         private static GameObject _blackHoleAmbience;
@@ -45,14 +46,8 @@ namespace NewHorizons.Builder.Body
         private static GameObject _whiteHoleRulesetVolume;
         private static GameObject _whiteHoleVolume;
 
-        private static bool _isInit;
-
         internal static void InitPrefabs()
         {
-            if (_isInit) return;
-
-            _isInit = true;
-
             if (_blackHoleProxyPrefab == null) _blackHoleProxyPrefab = SearchUtilities.Find(_blackHoleProxyPath).InstantiateInactive().Rename("BlackHoleSingularity").DontDestroyOnLoad();
             if (_whiteHoleProxyPrefab == null) _whiteHoleProxyPrefab = SearchUtilities.Find(_whiteHoleProxyPath).InstantiateInactive().Rename("WhiteHoleSingularity").DontDestroyOnLoad();
 
@@ -72,13 +67,14 @@ namespace NewHorizons.Builder.Body
             if (_whiteHoleVolume == null) _whiteHoleVolume = SearchUtilities.Find("WhiteHole_Body/WhiteHoleVolume").InstantiateInactive().Rename("WhiteHoleVolume").DontDestroyOnLoad();
         }
 
+        public static void Init()
+        {
+            _singularitiesByID = new Dictionary<string, GameObject>();
+            _pairsToLink = new List<(string, string)>();
+        }
+
         public static void Make(GameObject go, Sector sector, OWRigidbody OWRB, PlanetConfig config, SingularityModule singularity)
         {
-            InitPrefabs();
-
-            // If we've reloaded the first one will now be null so we have to refresh the list
-            if (_singularitiesByID?.Values?.FirstOrDefault() == null) _singularitiesByID = new Dictionary<string, GameObject>();
-
             var horizonRadius = singularity.horizonRadius;
             var distortRadius = singularity.distortRadius != 0f ? singularity.distortRadius : horizonRadius * 2.5f;
             var pairedSingularity = singularity.pairedSingularity;
@@ -95,51 +91,57 @@ namespace NewHorizons.Builder.Body
                 hasHazardVolume, singularity.targetStarSystem, singularity.curve, singularity.hasWarpEffects, singularity.renderQueueOverride, singularity.rename, singularity.parentPath, singularity.isRelativeToParent);
 
             var uniqueID = string.IsNullOrEmpty(singularity.uniqueID) ? config.name : singularity.uniqueID;
+            
             _singularitiesByID.Add(uniqueID, newSingularity);
-
-            // Try to pair them
-            if (!string.IsNullOrEmpty(pairedSingularity) && newSingularity != null)
+            if (!string.IsNullOrEmpty(pairedSingularity))
             {
-                if (_singularitiesByID.TryGetValue(pairedSingularity, out var pairedSingularityGO))
+                if (polarity)
                 {
-                    switch (polarity)
-                    {
-                        case true:
-                            PairSingularities(uniqueID, pairedSingularity, newSingularity, pairedSingularityGO);
-                            break;
-                        case false:
-                            PairSingularities(pairedSingularity, uniqueID, pairedSingularityGO, newSingularity);
-                            break;
-                    }
+                    _pairsToLink.Add((uniqueID, pairedSingularity));
+                }
+                else
+                {
+                    _pairsToLink.Add((pairedSingularity, uniqueID));
                 }
             }
+
         }
 
-        public static void PairSingularities(string blackHoleID, string whiteHoleID, GameObject blackHole, GameObject whiteHole)
+        public static void PairAllSingularities()
         {
-            InitPrefabs();
-
-            if (blackHole == null || whiteHole == null) return;
-
-            Logger.LogVerbose($"Pairing singularities [{blackHoleID}], [{whiteHoleID}]");
-
-            var whiteHoleVolume = whiteHole.GetComponentInChildren<WhiteHoleVolume>();
-            var blackHoleVolume = blackHole.GetComponentInChildren<BlackHoleVolume>();
-
-            if (whiteHoleVolume == null || blackHoleVolume == null)
+            foreach (var pair in _pairsToLink)
             {
-                Logger.LogWarning($"[{blackHoleID}] and [{whiteHoleID}] do not have compatible polarities");
-                return;
+                var (blackHoleID, whiteHoleID) = pair;
+                if (!_singularitiesByID.TryGetValue(blackHoleID, out GameObject blackHole))
+                {
+                    Logger.LogWarning($"Black hole [{blackHoleID}] is missing.");
+                    break;
+                }
+                if (!_singularitiesByID.TryGetValue(whiteHoleID, out GameObject whiteHole))
+                {
+                    Logger.LogWarning($"White hole [{whiteHoleID}] is missing.");
+                    break;
+                }
+                var whiteHoleVolume = whiteHole.GetComponentInChildren<WhiteHoleVolume>();
+                var blackHoleVolume = blackHole.GetComponentInChildren<BlackHoleVolume>();
+                if (whiteHoleVolume == null || blackHoleVolume == null)
+                {
+                    Logger.LogWarning($"Singularities [{blackHoleID}] and [{whiteHoleID}] do not have compatible polarities.");
+                    break;
+                }
+                if (blackHoleVolume._whiteHole != null && blackHoleVolume._whiteHole != whiteHoleVolume)
+                {
+                    Logger.LogWarning($"Black hole [{blackHoleID}] has already been linked!");
+                    break;
+                }
+                Logger.LogVerbose($"Pairing singularities [{blackHoleID}], [{whiteHoleID}]");
+                blackHoleVolume._whiteHole = whiteHoleVolume;
             }
-
-            blackHoleVolume._whiteHole = whiteHoleVolume;
         }
 
         public static GameObject MakeSingularity(GameObject planetGO, Sector sector, Vector3 position, Vector3 rotation, bool polarity, float horizon, float distort,
             bool hasDestructionVolume, string targetStarSystem = null, TimeValuePair[] curve = null, bool warpEffects = true, int renderQueue = 2985, string rename = null, string parentPath = null, bool isRelativeToParent = false)
         {
-            InitPrefabs();
-
             // polarity true = black, false = white
 
             var info = new SingularityModule
@@ -272,8 +274,6 @@ namespace NewHorizons.Builder.Body
         
         public static MeshRenderer MakeSingularityGraphics(GameObject singularity, bool polarity, float horizon, float distort, int queue = 2985)
         {
-            InitPrefabs();
-
             var singularityRenderer = new GameObject(polarity ? "BlackHoleRenderer" : "WhiteHoleRenderer");
             singularityRenderer.transform.parent = singularity.transform;
             singularityRenderer.transform.localPosition = Vector3.zero;
@@ -296,8 +296,6 @@ namespace NewHorizons.Builder.Body
 
         public static GameObject MakeSingularityProxy(GameObject rootObject, MVector3 position, bool polarity, float horizon, float distort, TimeValuePair[] curve = null, int queue = 2985)
         {
-            InitPrefabs();
-
             var singularityRenderer = MakeSingularityGraphics(rootObject, polarity, horizon, distort, queue);
             if (position != null) singularityRenderer.transform.localPosition = position;
 

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -131,6 +131,8 @@ namespace NewHorizons.Handlers
 
             Logger.Log("Done loading bodies");
 
+            SingularityBuilder.PairAllSingularities();
+
             // Events.FireOnNextUpdate(PlanetDestroyer.RemoveAllProxies);
 
             if (Main.SystemDict[Main.Instance.CurrentStarSystem].Config.destroyStockPlanets) PlanetDestructionHandler.RemoveStockPlanets();

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -376,6 +376,7 @@ namespace NewHorizons
                 AudioTypeHandler.Init();
                 InterferenceHandler.Init();
                 RemoteHandler.Init();
+                SingularityBuilder.Init();
                 AtmosphereBuilder.Init();
                 BrambleNodeBuilder.Init(BodyDict[CurrentStarSystem].Select(x => x.Config).Where(x => x.Bramble?.dimension != null).ToArray());
 


### PR DESCRIPTION

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- Deferred singularity linking until after all planets are built, so build order no longer affects pairs where only one has `pairedSingularity` set.