### PR TITLE
1.10.1

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -98,7 +98,7 @@ namespace NewHorizons.Builder.Props
             {
                 prop = GeneralPropBuilder.MakeFromPrefab(prefab, prefab.name, go, sector, detail);
 
-                StreamingHandler.SetUpStreaming(prop, sector);
+                StreamingHandler.SetUpStreaming(prop, detail.keepLoaded ? null : sector);
 
                 // Could check this in the for loop but I'm not sure what order we need to know about this in
                 var isTorch = prop.GetComponent<VisionTorchItem>() != null;

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "owmlVersion": "2.9.0",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Major features
- Nomai warp pads! You can build transmitters (like the towers on Ash Twin) and receivers on other planets. Can also be used to just make permanent teleportation pads if the alignment window is set to 360 degrees. Receivers also take in general prop arguments for a Nomai computer which will display the departure and arrival times.

## Minor features
- Adds `gameOverText` and `deathType` to credits volumes to display orange text explaining the ending. (#512)
- Unified parenting, positioning, and rotating code across all prop-like objects, adding support for parent-relative offsets and rotations to rafts, geysers, tornados, volcanos, and others. All prop-like objects have the common fields `rename`, `parentPath`, and `isRelativeToParent`, as well as any applicable position and rotation fields.
    - Added `alignRadial` to all props with rotations, replacing `alignToNormal` on details. This now stacks with normal rotations, where behavior was inconsistent before.
    - `translatorText` props now behave like other props in terms of positioning and rotating. `normal` is no longer used to calculate rotations of some objects; instead you can use `alignRadial` and/or `rotation`. Wall text continues to use `normal` to indicate the direction of the surface to align the text to. Existing `nomaiText` wall text and props are unaffected by all of these changes.
    - Moved the Spawn module player spawn and ship spawn fields to new `playerSpawn` and `shipSpawn` prop-like object fields.
    - Moved dialogue remote trigger fields to a new `remoteTrigger` prop-like object field.
    - Moved the Vessel module vessel location and warp exit location fields to new `vesselSpawn` and `warpExit` prop-like object fields. They also have a `parentBody` field to specify the planet to attach them to.
    - Made quantum group sockets and bramble nodes/seeds prop-like objects.
- Other Vessel changes
    - Added a new `alwaysPresent` property to the Vessel module to spawn the vessel whether it was used to warp to the system or not, and a `spawnOnVessel` property to always spawn on the vessel when entering the system, if it is present.
    - Added a new `hasPhysics` property to the Vessel module to allow users to disable the default behavior of the vessel floating on its own and allow it to be parented to other planets or bodies.
    - Added a new `attachToVessel` property to `warpExit` to keep the old behavior of the warp exit following the vessel.
- Added a `whiteboard` type to `translatorText` props. If `xmlFile` is set, it will spawn with a scroll already inserted with that text.

## Improvements
- Improved error logging when a detail fails to be created because a script component's script is missing
- Added `isRelativeToParent` to geysers to match other prop-like objects.
- Added `rename` to signals to match other prop-like objects.
- Slightly better error logging if `xmlFile` is not provided for translator text props that require it
- Now we use nullable values in `translatorText` instead of separate `keepAutoPlacement` bool
- Deferred singularity linking until after all planets are built, so build order no longer affects pairs where only one has `pairedSingularity` set.

## Bug fixes
- Fixed a vanilla bug that would sometimes cause the camera's vertical rotation to get locked in place when spawning on the vessel
- Fixed several edge cases of props not respecting relative rotations when `isRelativeToParent` was set
- Fixed geyser rotations being slightly off due to inheriting the original prefab's rotation
- Fixed ship spawn points not actually being rotated, just the ship itself (only noticeable if re-using the spawn point game object after initial spawn)
- Details with `keepLoaded` will no longer have cull groups etc on them, so they should work in map mode. `keepLoaded` will also force streaming to be always loaded instead of just when you're in the sector.

## Note for add-on devs:
We rearranged some internal stuff, so if you were referencing the NH dll in your projects some stuff might have broken. Tested it only with addons that were actually released.