### PR TITLE
Add teenager arc type

### DIFF
--- a/NewHorizons/Builder/Props/NomaiTextBuilder.cs
+++ b/NewHorizons/Builder/Props/NomaiTextBuilder.cs
@@ -24,6 +24,7 @@ namespace NewHorizons.Builder.Props
     {
         private static List<GameObject> _arcPrefabs;
         private static List<GameObject> _childArcPrefabs;
+        private static GameObject _teenagerArcPrefab;
         private static List<GameObject> _ghostArcPrefabs;
         private static GameObject _scrollPrefab;
         private static GameObject _computerPrefab;
@@ -52,6 +53,7 @@ namespace NewHorizons.Builder.Props
 
         public static List<GameObject> GetArcPrefabs() { return _arcPrefabs; }
         public static List<GameObject> GetChildArcPrefabs() { return _childArcPrefabs; }
+        public static GameObject GetTeenagerArcPrefab() { return _teenagerArcPrefab; }
         public static List<GameObject> GetGhostArcPrefabs() { return _ghostArcPrefabs; }
 
         private static bool _isInit;
@@ -83,6 +85,12 @@ namespace NewHorizons.Builder.Props
                         _arcPrefabs.Add(existingArc.InstantiateInactive().Rename("Arc").DontDestroyOnLoad());
                     }
                 }
+            }
+
+            if (_teenagerArcPrefab == null)
+            {
+                _teenagerArcPrefab = GameObject.FindObjectsOfType<NomaiWallText>().FirstOrDefault(x => x.name.Equals("Arc_GD_StatueIsland_WindowNote"))
+                    ?.gameObject?.transform?.Find("Arc 1")?.gameObject.InstantiateInactive().Rename("Arc (Teenager)").DontDestroyOnLoad();
             }
 
             if (_ghostArcPrefabs == null)
@@ -666,6 +674,9 @@ namespace NewHorizons.Builder.Props
                         ? Random.Range(0, _childArcPrefabs.Count())
                         : (variation % _childArcPrefabs.Count());
                     arc = _childArcPrefabs[variation].InstantiateInactive();
+                    break;
+                case NomaiTextArcInfo.NomaiTextArcType.Teenager:
+                    arc = _teenagerArcPrefab.InstantiateInactive();
                     break;
                 case NomaiTextArcInfo.NomaiTextArcType.Stranger when _ghostArcPrefabs.Any():
                     variation = variation < 0

--- a/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
+++ b/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
@@ -565,6 +565,10 @@ namespace NewHorizons.Builder.Props.TranslatorText
                     profile = NomaiTextArcBuilder.childSpiralProfile;
                     mat = _childArcMaterial;
                     break;
+                case NomaiTextArcInfo.NomaiTextArcType.Teenager:
+                    profile = NomaiTextArcBuilder.adultSpiralProfile;
+                    mat = _childArcMaterial;
+                    break;
                 case NomaiTextArcInfo.NomaiTextArcType.Stranger when _ghostArcMaterial != null:
                     profile = NomaiTextArcBuilder.strangerSpiralProfile;
                     mat = _ghostArcMaterial;

--- a/NewHorizons/External/Modules/Props/TranslatorText/NomaiTextArcInfo.cs
+++ b/NewHorizons/External/Modules/Props/TranslatorText/NomaiTextArcInfo.cs
@@ -19,7 +19,9 @@ namespace NewHorizons.External.Modules.TranslatorText
 
             [EnumMember(Value = @"child")] Child = 1,
 
-            [EnumMember(Value = @"stranger")] Stranger = 2
+            [EnumMember(Value = @"stranger")] Stranger = 2,
+
+            [EnumMember(Value = @"teenager")] Teenager = 3
         }
 
         /// <summary>

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1516,12 +1516,14 @@
       "x-enumNames": [
         "Adult",
         "Child",
-        "Stranger"
+        "Stranger",
+        "Teenager"
       ],
       "enum": [
         "adult",
         "child",
-        "stranger"
+        "stranger",
+        "teenager"
       ]
     },
     "MVector2": {


### PR DESCRIPTION
Adds a new arc type to translator text. This is a mix between child and adult. It uses the adult mesh but the child texture.

Originally used at the window text on Giant's Deep's statue island.
![image](https://user-images.githubusercontent.com/34462599/233802747-d4f232c5-98fe-4fa7-a5e3-f351feac0f50.png)