### PR TITLE
basic generated texture cache

### DIFF
--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -18,45 +18,50 @@ namespace NewHorizons.Builder.General
 
             var light = lightGO.GetComponent<Light>();
             /*
-             * R is inner radius
-             * G is shell (1 for shell, 0 for no shell)
-             * B is always 1
-             * A is falloff exponent
-             */
+            * R is inner radius
+            * G is shell (1 for shell, 0 for no shell)
+            * B is always 1
+            * A is falloff exponent
+            */
 
             light.intensity = config.intensity;
             light.range = config.outerRadius ?? surfaceSize * 2;
             var innerRadius = config.innerRadius ?? surfaceSize;
             innerRadius = Mathf.Sqrt(innerRadius / light.range);
             var shell = config.isShell ? 1f : 0f;
-            light.color = new Color(innerRadius, shell, 1f, 0.0225f/*from timber hearth*/);
+            light.color = new Color(innerRadius, shell, 1f, 0.0225f /*from timber hearth*/);
 
             if (config.tint != null)
             {
                 var tint = config.tint.ToColor();
                 var key = $"AmbientLight_QM > tint {tint}";
-                if (ImageUtilities.CheckGeneratedTexture(key, out var existingTexture)) light.cookie = existingTexture;
-                
-                var baseCubemap = Main.NHPrivateAssetBundle.LoadAsset<Cubemap>("AmbientLight_QM");
-                var cubemap = new Cubemap(baseCubemap.width, baseCubemap.format, baseCubemap.mipmapCount != 1);
-                cubemap.name = key;
-                cubemap.wrapMode = baseCubemap.wrapMode;
-                for (int i = 0; i < 6; i++)
+                if (ImageUtilities.CheckGeneratedTexture(key, out var existingTexture))
                 {
-                    var cubemapFace = (CubemapFace)i;
-                    var sourceColors = baseCubemap.GetPixels(cubemapFace);
-                    var newColors = new Color[sourceColors.Length];
-                    for (int j = 0; j < sourceColors.Length; j++)
-                    {
-                        var grey = sourceColors[j].grayscale * 2; // looks nicer with multiplier
-                        newColors[j] = new Color(grey, grey, grey) * tint;
-                    }
-                    cubemap.SetPixels(newColors, cubemapFace);
+                    light.cookie = existingTexture;
                 }
-                cubemap.Apply();
-                ImageUtilities.TrackGeneratedTexture(key, cubemap);
-                
-                light.cookie = cubemap;
+                else
+                {
+                    var baseCubemap = Main.NHPrivateAssetBundle.LoadAsset<Cubemap>("AmbientLight_QM");
+                    var cubemap = new Cubemap(baseCubemap.width, baseCubemap.format, baseCubemap.mipmapCount != 1);
+                    cubemap.name = key;
+                    cubemap.wrapMode = baseCubemap.wrapMode;
+                    for (int i = 0; i < 6; i++)
+                    {
+                        var cubemapFace = (CubemapFace)i;
+                        var sourceColors = baseCubemap.GetPixels(cubemapFace);
+                        var newColors = new Color[sourceColors.Length];
+                        for (int j = 0; j < sourceColors.Length; j++)
+                        {
+                            var grey = sourceColors[j].grayscale * 2; // looks nicer with multiplier
+                            newColors[j] = new Color(grey, grey, grey) * tint;
+                        }
+                        cubemap.SetPixels(newColors, cubemapFace);
+                    }
+                    cubemap.Apply();
+                    ImageUtilities.TrackGeneratedTexture(key, cubemap);
+
+                    light.cookie = cubemap;
+                }
             }
 
             return light;

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -36,7 +36,7 @@ namespace NewHorizons.Builder.General
                 var tint = config.tint.ToColor();
                 var baseCubemap = Main.NHPrivateAssetBundle.LoadAsset<Cubemap>("AmbientLight_QM");
                 var cubemap = new Cubemap(baseCubemap.width, baseCubemap.format, baseCubemap.mipmapCount != 1);
-                cubemap.name = baseCubemap.name + "Tinted";
+                cubemap.name = $"{baseCubemap.name} > tint {tint}";
                 cubemap.wrapMode = baseCubemap.wrapMode;
                 for (int i = 0; i < 6; i++)
                 {

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -18,18 +18,18 @@ namespace NewHorizons.Builder.General
 
             var light = lightGO.GetComponent<Light>();
             /*
-            * R is inner radius
-            * G is shell (1 for shell, 0 for no shell)
-            * B is always 1
-            * A is falloff exponent
-            */
+             * R is inner radius
+             * G is shell (1 for shell, 0 for no shell)
+             * B is always 1
+             * A is falloff exponent
+             */
 
             light.intensity = config.intensity;
             light.range = config.outerRadius ?? surfaceSize * 2;
             var innerRadius = config.innerRadius ?? surfaceSize;
             innerRadius = Mathf.Sqrt(innerRadius / light.range);
             var shell = config.isShell ? 1f : 0f;
-            light.color = new Color(innerRadius, shell, 1f, 0.0225f /*from timber hearth*/);
+            light.color = new Color(innerRadius, shell, 1f, 0.0225f/*from timber hearth*/);
 
             if (config.tint != null)
             {

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -34,9 +34,12 @@ namespace NewHorizons.Builder.General
             if (config.tint != null)
             {
                 var tint = config.tint.ToColor();
+                var key = $"AmbientLight_QM > tint {tint}";
+                if (ImageUtilities.CheckGeneratedTexture(key, out var existingTexture)) light.cookie = existingTexture;
+                
                 var baseCubemap = Main.NHPrivateAssetBundle.LoadAsset<Cubemap>("AmbientLight_QM");
                 var cubemap = new Cubemap(baseCubemap.width, baseCubemap.format, baseCubemap.mipmapCount != 1);
-                cubemap.name = $"{baseCubemap.name} > tint {tint}";
+                cubemap.name = key;
                 cubemap.wrapMode = baseCubemap.wrapMode;
                 for (int i = 0; i < 6; i++)
                 {
@@ -51,7 +54,7 @@ namespace NewHorizons.Builder.General
                     cubemap.SetPixels(newColors, cubemapFace);
                 }
                 cubemap.Apply();
-                ImageUtilities.TrackGeneratedTexture(cubemap);
+                ImageUtilities.TrackGeneratedTexture(key, cubemap);
                 
                 light.cookie = cubemap;
             }

--- a/NewHorizons/Builder/General/AmbientLightBuilder.cs
+++ b/NewHorizons/Builder/General/AmbientLightBuilder.cs
@@ -35,7 +35,7 @@ namespace NewHorizons.Builder.General
             {
                 var tint = config.tint.ToColor();
                 var key = $"AmbientLight_QM > tint {tint}";
-                if (ImageUtilities.CheckGeneratedTexture(key, out var existingTexture))
+                if (ImageUtilities.CheckCachedTexture(key, out var existingTexture))
                 {
                     light.cookie = existingTexture;
                 }
@@ -58,7 +58,7 @@ namespace NewHorizons.Builder.General
                         cubemap.SetPixels(newColors, cubemapFace);
                     }
                     cubemap.Apply();
-                    ImageUtilities.TrackGeneratedTexture(key, cubemap);
+                    ImageUtilities.TrackCachedTexture(key, cubemap);
 
                     light.cookie = cubemap;
                 }

--- a/NewHorizons/Handlers/VesselCoordinatePromptHandler.cs
+++ b/NewHorizons/Handlers/VesselCoordinatePromptHandler.cs
@@ -11,6 +11,7 @@ namespace NewHorizons.Handlers
     public class VesselCoordinatePromptHandler
     {
         private static List<Tuple<string, string, ScreenPrompt>> _factSystemIDPrompt;
+        // TODO: move this to ImageUtilities
         private static List<Texture2D> _textureCache;
 
         public static void RegisterPrompts(List<NewHorizonsSystem> systems)

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -19,10 +19,12 @@ namespace NewHorizons.Utility.Files
         public static bool CheckCachedTexture(string key, out Texture existingTexture) => _textureCache.TryGetValue(key, out existingTexture);
         public static void TrackCachedTexture(string key, Texture texture) => _textureCache.Add(key, texture);
 
+        private static string GetKey(string path) => path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+
         public static bool IsTextureLoaded(IModBehaviour mod, string filename)
         {
             var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename);
-            var key = path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+            var key = GetKey(path);
             return _textureCache.ContainsKey(key);
         }
 
@@ -31,7 +33,7 @@ namespace NewHorizons.Utility.Files
         {
             // Copied from OWML but without the print statement lol
             var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename);
-            var key = path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+            var key = GetKey(path);
             if (_textureCache.TryGetValue(key, out var existingTexture))
             {
                 NHLogger.LogVerbose($"Already loaded image at path: {path}");
@@ -61,7 +63,7 @@ namespace NewHorizons.Utility.Files
         public static void DeleteTexture(IModBehaviour mod, string filename, Texture2D texture)
         {
             var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename);
-            var key = path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+            var key = GetKey(path);
             if (_textureCache.ContainsKey(key))
             {
                 if (_textureCache[key] == texture)
@@ -425,7 +427,7 @@ namespace NewHorizons.Utility.Files
 
             IEnumerator DownloadTexture(string url, int index)
             {
-                var key = url.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+                var key = GetKey(url);
                 lock (_textureCache)
                 {
                     if (_textureCache.TryGetValue(key, out var existingTexture))

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -14,13 +14,13 @@ namespace NewHorizons.Utility.Files
     public static class ImageUtilities
     {
         private static readonly Dictionary<string, Texture2D> _loadedTextures = new();
-        private static readonly List<Texture> _generatedTextures = new();
+        private static readonly Dictionary<string, Texture> _generatedTextures = new();
 
         /// <summary>
         /// Track textures generated outside of this file so they can be cleaned up on scene unload
         /// </summary>
         /// <param name="texture"></param>
-        public static void TrackGeneratedTexture(Texture texture) => _generatedTextures.Add(texture);
+        public static void TrackGeneratedTexture(Texture texture) => _generatedTextures.Add(texture.name, texture);
 
         public static bool IsTextureLoaded(IModBehaviour mod, string filename)
         {

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -84,13 +84,6 @@ namespace NewHorizons.Utility.Files
                 UnityEngine.Object.Destroy(texture);
             }
             _textureCache.Clear();
-
-            foreach (var texture in _textureCache.Values)
-            {
-                if (texture == null) continue;
-                UnityEngine.Object.Destroy(texture);
-            }
-            _textureCache.Clear();
         }
 
         public static Texture2D Invert(Texture2D texture)

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -33,7 +33,7 @@ namespace NewHorizons.Utility.Files
         {
             // Copied from OWML but without the print statement lol
             var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename);
-            var key = path.Substring(0, Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+            var key = path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
             if (_loadedTextures.TryGetValue(key, out var existingTexture))
             {
                 NHLogger.LogVerbose($"Already loaded image at path: {path}");
@@ -433,7 +433,7 @@ namespace NewHorizons.Utility.Files
 
             IEnumerator DownloadTexture(string url, int index)
             {
-                var key = url.Substring(0, Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
+                var key = url.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length);
                 lock (_loadedTextures)
                 {
                     if (_loadedTextures.TryGetValue(key, out var existingTexture))


### PR DESCRIPTION
<!-- A new module or something else important -->
## Major features
-

<!-- A new parameter added to a module, or API feature -->
## Minor features
-

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- generated textures are now cached. this should reduce memory usage
  - textures are named by file path and then the effects applied to them, for example `[path] > invert > tint [color]`

<!-- Be sure to reference the existing issue if it exists -->
## Bug fixes
-

fix #581