### PR TITLE
1.12.0

### DIFF
--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.11.2",
+  "version": "1.12.0",
   "owmlVersion": "2.9.0",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
Forgot to bump manifest oops

## Minor features
- Added the Ember Twin Cairn variant (resolves #591)

## Improvements
- Orbs now function!
- Renames the cairn NomaiTextType enums to what they actually are.

## Bug fixes
- Fixed fog in DLC location (had broken the Hazy Dreams addon) (Thanks Vio!)

