### PR TITLE
Adds a 5 second cooldown to warp transmitters after using return pad

### DIFF
--- a/NewHorizons/Builder/Props/WarpPadBuilder.cs
+++ b/NewHorizons/Builder/Props/WarpPadBuilder.cs
@@ -1,4 +1,5 @@
 using NewHorizons.Builder.Props.TranslatorText;
+using NewHorizons.Components;
 using NewHorizons.External.Modules.Props;
 using NewHorizons.External.Modules.WarpPad;
 using NewHorizons.Utility;
@@ -136,6 +137,9 @@ namespace NewHorizons.Builder.Props
             transmitter._upsideDown = info.flipAlignment;
 
             transmitter.GetComponent<BoxShape>().enabled = true;
+
+            // Prevents the transmitter from sending you straight back if you use the return function of the receiver #563
+            transmitterObject.AddComponent<NomaiWarpTransmitterCooldown>();
 
             transmitterObject.SetActive(true);
         }

--- a/NewHorizons/Components/NomaiWarpTransmitterCooldown.cs
+++ b/NewHorizons/Components/NomaiWarpTransmitterCooldown.cs
@@ -16,6 +16,14 @@ namespace NewHorizons.Components
             _transmitter.OnReceiveWarpedBody += _transmitter_OnReceiveWarpedBody;
         }
 
+        public void OnDestroy()
+        {
+            if (_transmitter != null)
+            {
+                _transmitter.OnReceiveWarpedBody -= _transmitter_OnReceiveWarpedBody;
+            }
+        }
+
         private void _transmitter_OnReceiveWarpedBody(OWRigidbody warpedBody, NomaiWarpPlatform startPlatform, NomaiWarpPlatform targetPlatform)
         {
             _cooldownActive = true;

--- a/NewHorizons/Components/NomaiWarpTransmitterCooldown.cs
+++ b/NewHorizons/Components/NomaiWarpTransmitterCooldown.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace NewHorizons.Components
+{
+    public class NomaiWarpTransmitterCooldown : MonoBehaviour
+    {
+        private NomaiWarpTransmitter _transmitter;
+        private NomaiWarpReceiver _receiver;
+
+        private float _reenabledTime = 0f;
+        private bool _cooldownActive;
+
+        public void Start()
+        {
+            _transmitter = GetComponent<NomaiWarpTransmitter>();
+            _transmitter.OnReceiveWarpedBody += _transmitter_OnReceiveWarpedBody;
+        }
+
+        private void _transmitter_OnReceiveWarpedBody(OWRigidbody warpedBody, NomaiWarpPlatform startPlatform, NomaiWarpPlatform targetPlatform)
+        {
+            _cooldownActive = true;
+
+            _reenabledTime = Time.time + 5f;
+            _receiver = _transmitter._targetReceiver;
+            _transmitter._targetReceiver = null;
+        }
+
+        public void FixedUpdate()
+        {
+            if (_cooldownActive && Time.time > _reenabledTime)
+            {
+                _cooldownActive = false;
+                _transmitter._targetReceiver = _receiver;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- Added a 5 second delay to warp transmitters after you come back through the return pad. Means 360 degree alignment target actually works when returning through it instead of sending you straight back. (resolves #563)
