### PR TITLE
Allow using pathToAnimController for recorders #520

### DIFF
--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -147,6 +147,7 @@ namespace NewHorizons.Builder.Props
             var controller = character.GetComponent<CharacterAnimController>();
             var traveler = character.GetComponent<TravelerController>();
             var travelerEye = character.GetComponent<TravelerEyeController>();
+            var hearthianRecorder = character.GetComponent<HearthianRecorderEffects>();
 
             var lookOnlyWhenTalking = info.lookAtRadius <= 0;
 
@@ -195,6 +196,11 @@ namespace NewHorizons.Builder.Props
                     dialogue.OnStartConversation += nomaiController.StartWatchingPlayer;
                     dialogue.OnEndConversation += nomaiController.StopWatchingPlayer;
                 }
+            }
+            else if (hearthianRecorder != null)
+            {
+                // #520
+                hearthianRecorder._characterDialogueTree = dialogue;
             }
             else
             {

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -199,8 +199,31 @@ namespace NewHorizons.Builder.Props
             }
             else if (hearthianRecorder != null)
             {
-                // #520
-                hearthianRecorder._characterDialogueTree = dialogue;
+                Delay.FireOnNextUpdate(() =>
+                {
+                    // #520
+                    if (hearthianRecorder._characterDialogueTree != null)
+                    {
+                        hearthianRecorder._characterDialogueTree.OnStartConversation -= hearthianRecorder.OnPlayRecorder;
+                        hearthianRecorder._characterDialogueTree.OnEndConversation -= hearthianRecorder.OnStopRecorder;
+                    }
+
+                    // Recorder props have their own dialogue on them already
+                    // Make sure to delete it when we're trying to connect new dialogue to it
+                    var existingDialogue = hearthianRecorder.GetComponent<CharacterDialogueTree>();
+                    if (existingDialogue != dialogue && existingDialogue != null)
+                    {
+                        // Can't delete the existing dialogue because its a required component but we can make it unable to select at least
+                        GameObject.Destroy(hearthianRecorder.GetComponent<OWCollider>());
+                        GameObject.Destroy(hearthianRecorder.GetComponent<SphereCollider>());
+                        GameObject.Destroy(existingDialogue._interactVolume);
+                        existingDialogue.enabled = false;
+                    }
+
+                    hearthianRecorder._characterDialogueTree = dialogue;
+                    hearthianRecorder._characterDialogueTree.OnStartConversation += hearthianRecorder.OnPlayRecorder;
+                    hearthianRecorder._characterDialogueTree.OnEndConversation += hearthianRecorder.OnStopRecorder;
+                });
             }
             else
             {

--- a/NewHorizons/External/Modules/Props/Dialogue/DialogueInfo.cs
+++ b/NewHorizons/External/Modules/Props/Dialogue/DialogueInfo.cs
@@ -25,6 +25,8 @@ namespace NewHorizons.External.Modules.Props.Dialogue
         /// CharacterAnimController, TravelerController, TravelerEyeController (eye of the universe), FacePlayerWhenTalking, 
         /// HearthianRecorderEffects or SolanumAnimController.
         /// 
+        /// If it's a Recorder this will also delete the existing dialogue already attached to that prop.
+        /// 
         /// If none of those components are present it will add a FacePlayerWhenTalking component.
         /// </summary>
         public string pathToAnimController;

--- a/NewHorizons/External/Modules/Props/Dialogue/DialogueInfo.cs
+++ b/NewHorizons/External/Modules/Props/Dialogue/DialogueInfo.cs
@@ -22,7 +22,8 @@ namespace NewHorizons.External.Modules.Props.Dialogue
 
         /// <summary>
         /// If this dialogue is meant for a character, this is the relative path from the planet to that character's
-        /// CharacterAnimController, TravelerController, TravelerEyeController (eye of the universe), FacePlayerWhenTalking, or SolanumAnimController.
+        /// CharacterAnimController, TravelerController, TravelerEyeController (eye of the universe), FacePlayerWhenTalking, 
+        /// HearthianRecorderEffects or SolanumAnimController.
         /// 
         /// If none of those components are present it will add a FacePlayerWhenTalking component.
         /// </summary>

--- a/NewHorizons/Patches/DialoguePatches/HearthianRecorderEffectsPatches.cs
+++ b/NewHorizons/Patches/DialoguePatches/HearthianRecorderEffectsPatches.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+
+namespace NewHorizons.Patches.DialoguePatches
+{
+    [HarmonyPatch(typeof(HearthianRecorderEffects))]
+    public static class HearthianRecorderEffectsPatches
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(HearthianRecorderEffects.Awake))]
+        public static bool HearthianRecorderEffects_Awake(HearthianRecorderEffects __instance)
+        {
+            // If we're adding custom dialogue to a recorder the CharacterDialogueTree isn't going to be on the object
+            if (__instance.GetComponent<CharacterDialogueTree>() == null)
+            {
+                __instance.enabled = false;
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1323,7 +1323,7 @@
         },
         "pathToAnimController": {
           "type": "string",
-          "description": "If this dialogue is meant for a character, this is the relative path from the planet to that character's\nCharacterAnimController, TravelerController, TravelerEyeController (eye of the universe), FacePlayerWhenTalking, \nHearthianRecorderEffects or SolanumAnimController.\n\nIf none of those components are present it will add a FacePlayerWhenTalking component."
+          "description": "If this dialogue is meant for a character, this is the relative path from the planet to that character's\nCharacterAnimController, TravelerController, TravelerEyeController (eye of the universe), FacePlayerWhenTalking, \nHearthianRecorderEffects or SolanumAnimController.\n\nIf it's a Recorder this will also delete the existing dialogue already attached to that prop.\n\nIf none of those components are present it will add a FacePlayerWhenTalking component."
         },
         "radius": {
           "type": "number",


### PR DESCRIPTION
<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- Can now use `pathToAnimController` on a character dialogue to link it to a Hearthian recorder so that it's visual effects will be triggered during the dialogue #520