### PR TITLE
Add repeatPopup field to addon-manifest

### DIFF
--- a/NewHorizons/External/Configs/AddonConfig.cs
+++ b/NewHorizons/External/Configs/AddonConfig.cs
@@ -26,5 +26,10 @@ namespace NewHorizons.External.Configs
         /// A pop-up message for the first time a user runs the add-on
         /// </summary>
         public string popupMessage;
+
+        /// <summary>
+        /// If popupMessage is set, should it repeat every time the game starts or only once
+        /// </summary>
+        public bool repeatPopup;
     }
 }

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -701,7 +701,7 @@ namespace NewHorizons
             }
             if (!string.IsNullOrEmpty(addonConfig.popupMessage))
             {
-                MenuHandler.RegisterOneTimePopup(mod, TranslationHandler.GetTranslation(addonConfig.popupMessage, TranslationHandler.TextType.UI));
+                MenuHandler.RegisterOneTimePopup(mod, TranslationHandler.GetTranslation(addonConfig.popupMessage, TranslationHandler.TextType.UI), addonConfig.repeatPopup);
             }
         }
 

--- a/NewHorizons/OtherMods/MenuFramework/MenuHandler.cs
+++ b/NewHorizons/OtherMods/MenuFramework/MenuHandler.cs
@@ -13,7 +13,7 @@ namespace NewHorizons.OtherMods.MenuFramework
     {
         private static IMenuAPI _menuApi;
 
-        private static List<(IModBehaviour mod, string message)> _registeredPopups = new();
+        private static List<(IModBehaviour mod, string message, bool repeat)> _registeredPopups = new();
         private static List<string> _failedFiles = new();
 
         public static void Init()
@@ -38,9 +38,9 @@ namespace NewHorizons.OtherMods.MenuFramework
                 _menuApi.RegisterStartupPopup(warning);
             }
 
-            foreach(var (mod, message) in _registeredPopups)
+            foreach(var (mod, message, repeat) in _registeredPopups)
             {
-                if (!NewHorizonsData.HasReadOneTimePopup(mod.ModHelper.Manifest.UniqueName))
+                if (repeat || !NewHorizonsData.HasReadOneTimePopup(mod.ModHelper.Manifest.UniqueName))
                 {
                     _menuApi.RegisterStartupPopup(TranslationHandler.GetTranslation(message, TranslationHandler.TextType.UI));
                     NewHorizonsData.ReadOneTimePopup(mod.ModHelper.Manifest.UniqueName);
@@ -64,6 +64,6 @@ namespace NewHorizons.OtherMods.MenuFramework
 
         public static void RegisterFailedConfig(string filename) => _failedFiles.Add(filename);
 
-        public static void RegisterOneTimePopup(IModBehaviour mod, string message) => _registeredPopups.Add((mod, message));
+        public static void RegisterOneTimePopup(IModBehaviour mod, string message, bool repeat) => _registeredPopups.Add((mod, message, repeat));
     }
 }

--- a/NewHorizons/Schemas/addon_manifest_schema.json
+++ b/NewHorizons/Schemas/addon_manifest_schema.json
@@ -23,6 +23,10 @@
       "type": "string",
       "description": "A pop-up message for the first time a user runs the add-on"
     },
+    "repeatPopup": {
+      "type": "boolean",
+      "description": "If popupMessage is set, should it repeat every time the game starts or only once"
+    },
     "$schema": {
       "type": "string",
       "description": "The schema to validate with"


### PR DESCRIPTION
## Minor features
- Starting popups can be shown multiple times using `repeatPopup` in the addon-manifest file #621