### PR TITLE
Spawn offset

### DIFF
--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -21,7 +21,6 @@ namespace NewHorizons.Builder.General
             if (module.playerSpawn != null)
             {
                 GameObject spawnGO = GeneralPropBuilder.MakeNew("PlayerSpawnPoint", planetGO, null, module.playerSpawn);
-                spawnGO.SetActive(false);
                 spawnGO.layer = Layer.PlayerSafetyCollider;
 
                 playerSpawn = spawnGO.AddComponent<SpawnPoint>();
@@ -31,8 +30,7 @@ namespace NewHorizons.Builder.General
                 playerSpawn._triggerVolumes = new OWTriggerVolume[0];
 
                 // This was a stupid hack to stop players getting stuck in the ground and now we have to keep it forever
-                spawnGO.transform.position += 4f * spawnGO.transform.up;
-                spawnGO.SetActive(true);
+                spawnGO.transform.position += spawnGO.transform.TransformDirection(module.playerSpawn.offset ?? Vector3.up * 4f);
             }
 
             if (module.shipSpawn != null)
@@ -57,7 +55,11 @@ namespace NewHorizons.Builder.General
                     ship.transform.rotation = spawnGO.transform.rotation;
 
                     // Move it up a bit more when aligning to surface
-                    if (module.shipSpawn.alignRadial.GetValueOrDefault())
+                    if (module.shipSpawn.offset != null)
+                    {
+                        ship.transform.position += spawnGO.transform.TransformDirection(module.shipSpawn.offset);
+                    }
+                    else if (module.shipSpawn.alignRadial.GetValueOrDefault())
                     {
                         ship.transform.position += ship.transform.up * 4f;
                     }

--- a/NewHorizons/External/Modules/SpawnModule.cs
+++ b/NewHorizons/External/Modules/SpawnModule.cs
@@ -24,7 +24,17 @@ namespace NewHorizons.External.Modules
         [Obsolete("startWithSuit is deprecated. Use playerSpawn.startWithSuit instead")] public bool startWithSuit;
 
         [JsonObject]
-        public class PlayerSpawnPoint : GeneralPropInfo {
+        public class SpawnPoint : GeneralPropInfo
+        {
+            /// <summary>
+            /// Offsets the player/ship by this local vector when spawning. Used to prevent spawning in the floor. Optional: defaults to (0, 4, 0).
+            /// </summary>
+            public MVector3? offset;
+        }
+
+        [JsonObject]
+        public class PlayerSpawnPoint : SpawnPoint
+        {
             /// <summary>
             /// If you spawn on a planet with no oxygen, you probably want to set this to true ;;)
             /// </summary>
@@ -33,10 +43,13 @@ namespace NewHorizons.External.Modules
             /// Whether this planet's spawn point is the one the player will initially spawn at, if multiple spawn points exist.
             /// </summary>
             public bool isDefault;
+
+
         }
 
         [JsonObject]
-        public class ShipSpawnPoint : GeneralPropInfo {
+        public class ShipSpawnPoint : SpawnPoint
+        {
         
         }
     }

--- a/NewHorizons/Handlers/PlanetDestructionHandler.cs
+++ b/NewHorizons/Handlers/PlanetDestructionHandler.cs
@@ -54,10 +54,11 @@ namespace NewHorizons.Handlers
 
         public static void RemoveSolarSystem()
         {
-            // Stop the sun from killing the player
+            // Stop the sun from killing the player if they spawn at the center of the solar system
             var sunVolumes = SearchUtilities.Find("Sun_Body/Sector_SUN/Volumes_SUN");
             sunVolumes.SetActive(false);
 
+            // Random shit breaks if we don't wait idk why
             foreach (var name in _solarSystemBodies)
             {
                 var ao = AstroObjectLocator.GetAstroObject(name);
@@ -65,7 +66,7 @@ namespace NewHorizons.Handlers
                 else NHLogger.LogError($"Couldn't find [{name}]");
             }
 
-            // Bring the sun back because why not
+            // Bring the sun back
             Delay.FireInNUpdates(() => { if (Locator.GetAstroObject(AstroObject.Name.Sun).gameObject.activeInHierarchy) { sunVolumes.SetActive(true); } }, 3);
         }
 

--- a/NewHorizons/Handlers/PlayerSpawnHandler.cs
+++ b/NewHorizons/Handlers/PlayerSpawnHandler.cs
@@ -40,7 +40,7 @@ namespace NewHorizons.Handlers
                 var matchInitialMotion = SearchUtilities.Find("Player_Body").GetComponent<MatchInitialMotion>();
                 if (matchInitialMotion != null) UnityEngine.Object.Destroy(matchInitialMotion);
 
-                Main.Instance.StartCoroutine(SpawnCoroutine(2));
+                Main.Instance.StartCoroutine(SpawnCoroutine(10));
             }
         }
 

--- a/NewHorizons/Handlers/PlayerSpawnHandler.cs
+++ b/NewHorizons/Handlers/PlayerSpawnHandler.cs
@@ -40,6 +40,7 @@ namespace NewHorizons.Handlers
                 var matchInitialMotion = SearchUtilities.Find("Player_Body").GetComponent<MatchInitialMotion>();
                 if (matchInitialMotion != null) UnityEngine.Object.Destroy(matchInitialMotion);
 
+                // Arbitrary number, depending on the machine some people die, some people fall through the floor, its very inconsistent
                 Main.Instance.StartCoroutine(SpawnCoroutine(10));
             }
         }


### PR DESCRIPTION
## Improvements
- Added `offset` to player and ship spawn positions. By default it moves them up by 4m to prevent clipping into the ground but this can be non ideal in cramped spawn locations.
