### PR TITLE
1.14.1

### DIFF
--- a/NewHorizons/Assets/GravityCannonComputer.xml
+++ b/NewHorizons/Assets/GravityCannonComputer.xml
@@ -1,6 +1,0 @@
-<NomaiObject>
-    <TextBlock>
-        <ID>1</ID>
-        <Text>The <![CDATA[<color=orange>shuttle</color>]]> is currently resting at <![CDATA[<color=lightblue>???</color>]]>.</Text>
-    </TextBlock>
-</NomaiObject>

--- a/NewHorizons/Assets/translations/english.json
+++ b/NewHorizons/Assets/translations/english.json
@@ -22,7 +22,9 @@
     "DEBUG_PLACE_TEXT": "Place Nomai Text",
     "DEBUG_UNDO": "Undo",
     "DEBUG_REDO": "Redo",
-    "Vessel": "Vessel",
+    "Vessel": "Vessel"
+  },
+  "OtherDictionary": {
     "NOMAI_SHUTTLE_COMPUTER": "The <![CDATA[<color=orange>shuttle</color>]]> is currently resting at <![CDATA[<color=lightblue>{0}</color>]]>."
   },
   "AchievementTranslations": {

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -4,6 +4,7 @@ using NewHorizons.Utility;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
 using System;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -102,6 +103,7 @@ namespace NewHorizons.Builder.General
                     {
                         handler.Method.Invoke(handler.Target, new object[] { command });
                     }
+                    spv._interactVolume._listInteractions.First(x => x.promptText == UITextType.SuitUpPrompt).interactionEnabled = true;
                 }
             }
         }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -258,7 +258,7 @@ namespace NewHorizons.Builder.Props
 
             // Not doing else if here because idk if any of the classes below implement ISectorGroup
 
-            if (component is Sector s && !existingSectors.Contains(s.GetParentSector()))
+            if (component is Sector s && s.GetParentSector() != null && !existingSectors.Contains(s.GetParentSector()))
             {
                 s.SetParentSector(sector);
             }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -112,7 +112,7 @@ namespace NewHorizons.Builder.Props
                 // Could check this in the for loop but I'm not sure what order we need to know about this in
                 isItem = false;
 
-                var existingSectors = new HashSet<Sector>(prop.GetComponentsInChildren<Sector>());
+                var existingSectors = new HashSet<Sector>(prop.GetComponentsInChildren<Sector>(true));
 
                 foreach (var component in prop.GetComponentsInChildren<Component>(true))
                 {
@@ -258,7 +258,7 @@ namespace NewHorizons.Builder.Props
 
             // Not doing else if here because idk if any of the classes below implement ISectorGroup
 
-            if (component is Sector s && existingSectors.Contains(s.GetParentSector()))
+            if (component is Sector s && !existingSectors.Contains(s.GetParentSector()))
             {
                 s.SetParentSector(sector);
             }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -257,7 +257,8 @@ namespace NewHorizons.Builder.Props
             }
 
             // Not doing else if here because idk if any of the classes below implement ISectorGroup
-
+            
+            // Null check else shuttles controls break
             if (component is Sector s && s.GetParentSector() != null && !existingSectors.Contains(s.GetParentSector()))
             {
                 s.SetParentSector(sector);

--- a/NewHorizons/Builder/Props/GravityCannonBuilder.cs
+++ b/NewHorizons/Builder/Props/GravityCannonBuilder.cs
@@ -159,7 +159,7 @@ namespace NewHorizons.Builder.Props
             var shuttle = ShuttleBuilder.Shuttles[id];
             var planet = AstroObjectLocator.GetPlanetName(shuttle.GetComponentInParent<AstroObject>());
 
-            var displayText = TranslationHandler.GetTranslation("NOMAI_SHUTTLE_COMPUTER", TranslationHandler.TextType.UI).Replace("{0}", planet);
+            var displayText = TranslationHandler.GetTranslation("NOMAI_SHUTTLE_COMPUTER", TranslationHandler.TextType.OTHER).Replace("{0}", planet);
             NHLogger.Log(displayText);
             var xmlContent = $"<NomaiObject>\r\n    <TextBlock>\r\n        <ID>1</ID>\r\n        <Text>{displayText}</Text>\r\n    </TextBlock>\r\n</NomaiObject>";
 

--- a/NewHorizons/Components/EOTE/CloakLocatorController.cs
+++ b/NewHorizons/Components/EOTE/CloakLocatorController.cs
@@ -1,6 +1,7 @@
 using NewHorizons.Components.Stars;
 using NewHorizons.Handlers;
 using NewHorizons.Utility.OWML;
+using System.Linq;
 using UnityEngine;
 
 namespace NewHorizons.Components.EOTE
@@ -12,11 +13,17 @@ namespace NewHorizons.Components.EOTE
         
         public void Start()
         {
-            // Enable and disable all cloaks, else Stranger state is weird at the start
-            foreach (var cloak in CloakHandler.Cloaks)
+            if (CloakHandler.Cloaks.Any())
             {
-                SetCurrentCloak(cloak);
-                cloak.enabled = false;
+                // Enable and disable all cloaks, else Stranger state is weird at the start
+                foreach (var cloak in CloakHandler.Cloaks)
+                {
+                    SetCurrentCloak(cloak);
+                    cloak.enabled = false;
+                }
+
+                // Make sure a cloak is enabled
+                SetCurrentCloak(CloakHandler.Cloaks.First());
             }
         }
 

--- a/NewHorizons/External/Configs/TranslationConfig.cs
+++ b/NewHorizons/External/Configs/TranslationConfig.cs
@@ -23,6 +23,11 @@ namespace NewHorizons.External.Configs
         /// </summary>
         public Dictionary<string, string> UIDictionary;
 
+        /// <summary>
+        /// Translation table for other text, will be taken verbatim without correcting CDATA
+        /// </summary>
+        public Dictionary<string, string> OtherDictionary;
+
         #region Achievements+
         // This only exists for schema generation, Achievements+ handles the parsing
 #pragma warning disable 0169
@@ -62,6 +67,10 @@ namespace NewHorizons.External.Configs
             if (dict.ContainsKey(nameof(UIDictionary)))
                 UIDictionary =
                     (Dictionary<string, string>) (dict[nameof(UIDictionary)] as JObject).ToObject(
+                        typeof(Dictionary<string, string>));
+            if (dict.ContainsKey(nameof(OtherDictionary)))
+                OtherDictionary =
+                    (Dictionary<string, string>)(dict[nameof(OtherDictionary)] as JObject).ToObject(
                         typeof(Dictionary<string, string>));
         }
     }

--- a/NewHorizons/Handlers/TranslationHandler.cs
+++ b/NewHorizons/Handlers/TranslationHandler.cs
@@ -11,12 +11,14 @@ namespace NewHorizons.Handlers
         private static Dictionary<TextTranslation.Language, Dictionary<string, string>> _shipLogTranslationDictionary = new();
         private static Dictionary<TextTranslation.Language, Dictionary<string, string>> _dialogueTranslationDictionary = new();
         private static Dictionary<TextTranslation.Language, Dictionary<string, string>> _uiTranslationDictionary = new();
+        private static Dictionary<TextTranslation.Language, Dictionary<string, string>> _otherTranslationDictionary = new();
 
         public enum TextType
         {
             SHIPLOG,
             DIALOGUE,
-            UI
+            UI,
+            OTHER
         }
 
         public static string GetTranslation(string text, TextType type) => GetTranslation(text, type, true);
@@ -36,6 +38,9 @@ namespace NewHorizons.Handlers
                     break;
                 case TextType.UI:
                     dictionary = _uiTranslationDictionary;
+                    break;                     
+                case TextType.OTHER:
+                    dictionary = _otherTranslationDictionary;
                     break;
                 default:
                     if (warn) NHLogger.LogVerbose($"Invalid TextType {type}");
@@ -93,12 +98,25 @@ namespace NewHorizons.Handlers
                 if (!_uiTranslationDictionary.ContainsKey(language)) _uiTranslationDictionary.Add(language, new Dictionary<string, string>());
                 foreach (var originalKey in config.UIDictionary.Keys)
                 {
-                    // Don't remove CDATA from UI
-                    var key = originalKey.Replace("&lt;", "<").Replace("&gt;", ">");
-                    var value = config.UIDictionary[originalKey].Replace("&lt;", "<").Replace("&gt;", ">");
+                    var key = originalKey.Replace("&lt;", "<").Replace("&gt;", ">").Replace("<![CDATA[", "").Replace("]]>", "");
+                    var value = config.UIDictionary[originalKey].Replace("&lt;", "<").Replace("&gt;", ">").Replace("<![CDATA[", "").Replace("]]>", "");
 
                     if (!_uiTranslationDictionary[language].ContainsKey(key)) _uiTranslationDictionary[language].Add(key, value);
                     else _uiTranslationDictionary[language][key] = value;
+                }
+            }
+
+            if (config.OtherDictionary != null && config.OtherDictionary.Count() > 0)
+            {
+                if (!_otherTranslationDictionary.ContainsKey(language)) _otherTranslationDictionary.Add(language, new Dictionary<string, string>());
+                foreach (var originalKey in config.OtherDictionary.Keys)
+                {
+                    // Don't remove CDATA
+                    var key = originalKey.Replace("&lt;", "<").Replace("&gt;", ">");
+                    var value = config.OtherDictionary[originalKey].Replace("&lt;", "<").Replace("&gt;", ">");
+
+                    if (!_otherTranslationDictionary[language].ContainsKey(key)) _otherTranslationDictionary[language].Add(key, value);
+                    else _otherTranslationDictionary[language][key] = value;
                 }
             }
         }

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -634,6 +634,8 @@ namespace NewHorizons
         {
             try
             {
+                if (mod.ModHelper.Manifest.Filename.Contains("Extinction")) return;
+
                 if (_firstLoad)
                 {
                     MountedAddons.Add(mod);

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -8,7 +8,6 @@ using NewHorizons.External.Modules.Props;
 using NewHorizons.External.Modules.Props.Audio;
 using NewHorizons.External.Modules.Props.Dialogue;
 using NewHorizons.External.SerializableData;
-using NewHorizons.OtherMods.MenuFramework;
 using NewHorizons.Utility;
 using NewHorizons.Utility.OWML;
 using Newtonsoft.Json;
@@ -62,7 +61,7 @@ namespace NewHorizons
                 if (!Main.BodyDict.ContainsKey(body.Config.starSystem)) Main.BodyDict.Add(body.Config.starSystem, new List<NewHorizonsBody>());
                 Main.BodyDict[body.Config.starSystem].Add(body);
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 NHLogger.LogError($"Error in Create API:\n{ex}");
             }
@@ -143,7 +142,8 @@ namespace NewHorizons
         public T QueryBody<T>(string bodyName, string jsonPath)
         {
             var data = QueryBody(typeof(T), bodyName, jsonPath);
-            if (data is T result) {
+            if (data is T result)
+            {
                 return result;
             }
             return default;
@@ -152,14 +152,16 @@ namespace NewHorizons
         public object QuerySystem(Type outType, string jsonPath)
         {
             var system = Main.SystemDict[Main.Instance.CurrentStarSystem];
-            return system == null 
-                ? null 
+            return system == null
+                ? null
                 : QueryJson(outType, Path.Combine(system.Mod.ModHelper.Manifest.ModFolderPath, system.RelativePath), jsonPath);
         }
 
-        public T QuerySystem<T>(string jsonPath) {
+        public T QuerySystem<T>(string jsonPath)
+        {
             var data = QuerySystem(typeof(T), jsonPath);
-            if (data is T result) {
+            if (data is T result)
+            {
                 return result;
             }
             return default;
@@ -169,7 +171,8 @@ namespace NewHorizons
             float scale, bool alignRadial)
         {
             var prefab = SearchUtilities.Find(propToCopyPath);
-            var detailInfo = new DetailInfo() {
+            var detailInfo = new DetailInfo()
+            {
                 position = position,
                 rotation = eulerAngles,
                 scale = scale,
@@ -199,8 +202,8 @@ namespace NewHorizons
             return SignalBuilder.Make(root, null, info, mod).GetComponent<AudioSignal>();
         }
 
-        public (CharacterDialogueTree, RemoteDialogueTrigger) SpawnDialogue(IModBehaviour mod, GameObject root, string xmlFile, float radius = 1f, 
-            float range = 1f, string blockAfterPersistentCondition = null, float lookAtRadius = 1f, string pathToAnimController = null, 
+        public (CharacterDialogueTree, RemoteDialogueTrigger) SpawnDialogue(IModBehaviour mod, GameObject root, string xmlFile, float radius = 1f,
+            float range = 1f, string blockAfterPersistentCondition = null, float lookAtRadius = 1f, string pathToAnimController = null,
             float remoteTriggerRadius = 0f)
         {
             var info = new DialogueInfo()

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -1,6 +1,4 @@
-using HarmonyLib;
-using System.Collections.Generic;
-using System.Reflection.Emit;
+﻿using HarmonyLib;
 using UnityEngine;
 
 namespace NewHorizons.Patches;
@@ -10,40 +8,31 @@ public class GlobalMusicControllerPatches
 {
 	private static AudioDetector _audioDetector;
 
-    [HarmonyTranspiler]
-    [HarmonyPatch(nameof(GlobalMusicController.UpdateBrambleMusic))]
-	public static IEnumerable<CodeInstruction> GlobalMusicController_UpdateBrambleMusic(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-    {
-        // This transpiler is to the check if dark bramble music should be playing #651
-        // It essentially adds another boolean to a "should be playing" flag 
-        return new CodeMatcher(instructions, generator)
-        // All the other bools point to this so we make a label there
-        .MatchForward(false,
-            new CodeMatch(OpCodes.Ldc_I4_0),
-            new CodeMatch(OpCodes.Stloc_0),
-            new CodeMatch(OpCodes.Ldarg_0),
-            new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(GlobalMusicController), nameof(GlobalMusicController._darkBrambleSource))),
-            new CodeMatch(OpCodes.Callvirt, AccessTools.Property(typeof(OWAudioSource), nameof(OWAudioSource.isPlaying)).GetGetMethod())
-        )
-        .CreateLabel(out Label label)
-        // Find the first part of the boolean assignment
-        .Start()
-        .MatchForward(true,
-            new CodeMatch(OpCodes.Call, typeof(Locator), nameof(Locator.GetPlayerSectorDetector)),
-            new CodeMatch(OpCodes.Callvirt, typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension)),
-            new CodeMatch(OpCodes.Brfalse_S)
-        )
-        // Insert a new check to it pointing to the same label as the others
-        .Insert(
-            new CodeMatch(OpCodes.Call, typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes)),
-            new CodeMatch(OpCodes.Brfalse_S, label)
-        )
-        .InstructionEnumeration();
-	}
+	[HarmonyPrefix]
+	[HarmonyPatch(nameof(GlobalMusicController.UpdateBrambleMusic))]
+	public static bool GlobalMusicController_UpdateBrambleMusic(GlobalMusicController __instance)
+	{
+		// is this too hacky?
+		if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
 
-    private static bool IsPlayerInNoAudioVolumes()
-    {
-        if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
-        return _audioDetector._activeVolumes.Count == 0;
-    }
+
+		var shouldBePlaying = Locator.GetPlayerSectorDetector().InBrambleDimension() &&
+			!Locator.GetPlayerSectorDetector().InVesselDimension() &&
+			PlayerState.AtFlightConsole() &&
+			!PlayerState.IsHullBreached() &&
+			!__instance._playingFinalEndTimes &&
+			_audioDetector._activeVolumes.Count == 0; // change - don't play if in another audio volume
+		var playing = __instance._darkBrambleSource.isPlaying &&
+			!__instance._darkBrambleSource.IsFadingOut();
+		if (shouldBePlaying && !playing)
+		{
+			__instance._darkBrambleSource.FadeIn(5f);
+		}
+		else if (!shouldBePlaying && playing)
+		{
+			__instance._darkBrambleSource.FadeOut(5f);
+		}
+
+		return false;
+	}
 }

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace NewHorizons.Patches;
 
 [HarmonyPatch(typeof(GlobalMusicController))]
-public class GlobalMusicControllerPatches
+public static class GlobalMusicControllerPatches
 {
 	private static AudioDetector _audioDetector;
 
@@ -29,19 +29,19 @@ public class GlobalMusicControllerPatches
         // Find the first part of the boolean assignment
         .Start()
         .MatchForward(true,
-            new CodeMatch(OpCodes.Call, typeof(Locator), nameof(Locator.GetPlayerSectorDetector)),
-            new CodeMatch(OpCodes.Callvirt, typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension)),
+            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Locator), nameof(Locator.GetPlayerSectorDetector))),
+            new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension))),
             new CodeMatch(OpCodes.Brfalse_S)
         )
         // Insert a new check to it pointing to the same label as the others
         .Insert(
-            new CodeMatch(OpCodes.Call, typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes)),
+            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
             new CodeMatch(OpCodes.Brfalse_S, label)
         )
         .InstructionEnumeration();
 	}
 
-    private static bool IsPlayerInNoAudioVolumes()
+    public static bool IsPlayerInNoAudioVolumes()
     {
         if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
         return _audioDetector._activeVolumes.Count == 0;

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -1,4 +1,6 @@
-﻿using HarmonyLib;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace NewHorizons.Patches;
@@ -8,31 +10,40 @@ public class GlobalMusicControllerPatches
 {
 	private static AudioDetector _audioDetector;
 
-	[HarmonyPrefix]
-	[HarmonyPatch(nameof(GlobalMusicController.UpdateBrambleMusic))]
-	public static bool GlobalMusicController_UpdateBrambleMusic(GlobalMusicController __instance)
-	{
-		// is this too hacky?
-		if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
-
-
-		var shouldBePlaying = Locator.GetPlayerSectorDetector().InBrambleDimension() &&
-			!Locator.GetPlayerSectorDetector().InVesselDimension() &&
-			PlayerState.AtFlightConsole() &&
-			!PlayerState.IsHullBreached() &&
-			!__instance._playingFinalEndTimes &&
-			_audioDetector._activeVolumes.Count == 0; // change - don't play if in another audio volume
-		var playing = __instance._darkBrambleSource.isPlaying &&
-			!__instance._darkBrambleSource.IsFadingOut();
-		if (shouldBePlaying && !playing)
-		{
-			__instance._darkBrambleSource.FadeIn(5f);
-		}
-		else if (!shouldBePlaying && playing)
-		{
-			__instance._darkBrambleSource.FadeOut(5f);
-		}
-
-		return false;
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(GlobalMusicController.UpdateBrambleMusic))]
+	public static IEnumerable<CodeInstruction> GlobalMusicController_UpdateBrambleMusic(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+    {
+        // This transpiler is to the check if dark bramble music should be playing #651
+        // It essentially adds another boolean to a "should be playing" flag 
+        return new CodeMatcher(instructions, generator)
+        // All the other bools point to this so we make a label there
+        .MatchForward(false,
+            new CodeMatch(OpCodes.Ldc_I4_0),
+            new CodeMatch(OpCodes.Stloc_0),
+            new CodeMatch(OpCodes.Ldarg_0),
+            new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(GlobalMusicController), nameof(GlobalMusicController._darkBrambleSource))),
+            new CodeMatch(OpCodes.Callvirt, AccessTools.Property(typeof(OWAudioSource), nameof(OWAudioSource.isPlaying)).GetGetMethod())
+        )
+        .CreateLabel(out Label label)
+        // Find the first part of the boolean assignment
+        .Start()
+        .MatchForward(true,
+            new CodeMatch(OpCodes.Call, typeof(Locator), nameof(Locator.GetPlayerSectorDetector)),
+            new CodeMatch(OpCodes.Callvirt, typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension)),
+            new CodeMatch(OpCodes.Brfalse_S)
+        )
+        // Insert a new check to it pointing to the same label as the others
+        .Insert(
+            new CodeMatch(OpCodes.Call, typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes)),
+            new CodeMatch(OpCodes.Brfalse_S, label)
+        )
+        .InstructionEnumeration();
 	}
+
+    private static bool IsPlayerInNoAudioVolumes()
+    {
+        if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
+        return _audioDetector._activeVolumes.Count == 0;
+    }
 }

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -1,6 +1,4 @@
 using HarmonyLib;
-using NewHorizons.Patches.WarpPatches;
-using NewHorizons.Utility.OWML;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using UnityEngine;
@@ -37,8 +35,8 @@ public static class GlobalMusicControllerPatches
         )
         // Insert a new check to it pointing to the same label as the others
         .Insert(
-            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
-            new CodeInstruction(OpCodes.Brfalse_S, label)
+            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
+            new CodeMatch(OpCodes.Brfalse_S, label)
         )
         .InstructionEnumeration();
 	}

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace NewHorizons.Patches;
 
 [HarmonyPatch(typeof(GlobalMusicController))]
-public static class GlobalMusicControllerPatches
+public class GlobalMusicControllerPatches
 {
 	private static AudioDetector _audioDetector;
 
@@ -29,19 +29,19 @@ public static class GlobalMusicControllerPatches
         // Find the first part of the boolean assignment
         .Start()
         .MatchForward(true,
-            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Locator), nameof(Locator.GetPlayerSectorDetector))),
-            new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension))),
+            new CodeMatch(OpCodes.Call, typeof(Locator), nameof(Locator.GetPlayerSectorDetector)),
+            new CodeMatch(OpCodes.Callvirt, typeof(PlayerSectorDetector), nameof(PlayerSectorDetector.InBrambleDimension)),
             new CodeMatch(OpCodes.Brfalse_S)
         )
         // Insert a new check to it pointing to the same label as the others
         .Insert(
-            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
+            new CodeMatch(OpCodes.Call, typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes)),
             new CodeMatch(OpCodes.Brfalse_S, label)
         )
         .InstructionEnumeration();
 	}
 
-    public static bool IsPlayerInNoAudioVolumes()
+    private static bool IsPlayerInNoAudioVolumes()
     {
         if (_audioDetector == null) _audioDetector = Object.FindObjectOfType<AudioDetector>();
         return _audioDetector._activeVolumes.Count == 0;

--- a/NewHorizons/Patches/GlobalMusicControllerPatches.cs
+++ b/NewHorizons/Patches/GlobalMusicControllerPatches.cs
@@ -1,4 +1,6 @@
 using HarmonyLib;
+using NewHorizons.Patches.WarpPatches;
+using NewHorizons.Utility.OWML;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 using UnityEngine;
@@ -35,8 +37,8 @@ public static class GlobalMusicControllerPatches
         )
         // Insert a new check to it pointing to the same label as the others
         .Insert(
-            new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
-            new CodeMatch(OpCodes.Brfalse_S, label)
+            new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(GlobalMusicControllerPatches), nameof(GlobalMusicControllerPatches.IsPlayerInNoAudioVolumes))),
+            new CodeInstruction(OpCodes.Brfalse_S, label)
         )
         .InstructionEnumeration();
 	}

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.12.7",
+  "version": "1.13.0",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.12.6",
+  "version": "1.12.7",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Minor features
- Add option to freeze a physics detail until its touched. Good for things in zero G, to avoid them drifting away before the player can interact with them.
- `AddPhysics` on `Base` module for planets allows a planet to be pushed out of orbit. Intended for satellites or small props floating in orbit. Implements #194

## Bug Fixes
- Fix default system override being unreliable #687