### PR TITLE
Fix flares being white #668

### DIFF
--- a/NewHorizons/Builder/Body/StarBuilder.cs
+++ b/NewHorizons/Builder/Body/StarBuilder.cs
@@ -8,6 +8,7 @@ using NewHorizons.Components.Stars;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.OWML;
+using UnityEngine.InputSystem.XR;
 
 namespace NewHorizons.Builder.Body
 {
@@ -54,6 +55,7 @@ namespace NewHorizons.Builder.Body
             if (_starSurface == null) _starSurface = SearchUtilities.Find("Sun_Body/Sector_SUN/Geometry_SUN/Surface").InstantiateInactive().Rename("Prefab_Surface_Star").DontDestroyOnLoad();
             if (_starSolarFlareEmitter == null) _starSolarFlareEmitter = SearchUtilities.Find("Sun_Body/Sector_SUN/Effects_SUN/SolarFlareEmitter").InstantiateInactive().Rename("Prefab_SolarFlareEmitter_Star").DontDestroyOnLoad();
             if (_supernovaPrefab == null) _supernovaPrefab = SearchUtilities.Find("Sun_Body/Sector_SUN/Effects_SUN/Supernova").InstantiateInactive().Rename("Prefab_Supernova").DontDestroyOnLoad();
+            
             if (_mainSequenceMaterial == null) _mainSequenceMaterial = new Material(SearchUtilities.Find("Sun_Body").GetComponent<SunController>()._startSurfaceMaterial).DontDestroyOnLoad();
             if (_giantMaterial == null) _giantMaterial = new Material(SearchUtilities.Find("Sun_Body").GetComponent<SunController>()._endSurfaceMaterial).DontDestroyOnLoad();
             if (_flareMaterial == null)
@@ -344,7 +346,6 @@ namespace NewHorizons.Builder.Body
             solarFlareEmitter.transform.localPosition = Vector3.zero;
             solarFlareEmitter.transform.localScale = Vector3.one;
             solarFlareEmitter.name = "SolarFlareEmitter";
-            solarFlareEmitter.SetActive(true);
 
             var emitter = solarFlareEmitter.GetComponent<SolarFlareEmitter>();
 
@@ -361,10 +362,19 @@ namespace NewHorizons.Builder.Body
             }
 
             var material = new Material(_flareMaterial);
-            // Since the star isn't awake yet the controllers haven't been made 
-            foreach (var prefab in new GameObject[] { emitter.domePrefab, emitter.loopPrefab, emitter.streamerPrefab })
+
+            // Make our own copies of all prefabs to make sure we don't actually modify them
+            // else it will affect any other star using these prefabs
+            // #668
+            emitter._domePrefab = emitter.domePrefab.InstantiateInactive();
+            emitter._loopPrefab = emitter.loopPrefab.InstantiateInactive();
+            emitter._streamerPrefab = emitter.streamerPrefab.InstantiateInactive();
+
+            // Get all possible controllers, prefabs or already created ones
+            foreach (var controller in new GameObject[] { emitter.domePrefab, emitter.loopPrefab, emitter.streamerPrefab }
+                .Select(x => x.GetComponent<SolarFlareController>())
+                .Concat(emitter.GetComponentsInChildren<SolarFlareController>()))
             {
-                var controller = prefab.GetComponent<SolarFlareController>();
                 // controller._meshRenderer doesn't exist yet since Awake hasn't been called
                 if (starModule.tint != null)
                 {
@@ -376,6 +386,8 @@ namespace NewHorizons.Builder.Body
                 {
                     controller._scaleFactor = Vector3.one * starModule.solarFlareSettings.scaleFactor;
                 }
+                controller.gameObject.SetActive(true);
+                controller.enabled = true;
             }
 
             starGO.transform.position = rootObject.transform.position;
@@ -412,6 +424,8 @@ namespace NewHorizons.Builder.Body
                     surface.sharedMaterial.SetTexture(ColorRamp, ramp);
                 }
             }
+
+            solarFlareEmitter.SetActive(true);
 
             return starGO;
         }

--- a/NewHorizons/Builder/Body/StarBuilder.cs
+++ b/NewHorizons/Builder/Body/StarBuilder.cs
@@ -1,14 +1,12 @@
 using NewHorizons.Components.SizeControllers;
-using NewHorizons.Utility;
-using UnityEngine;
+using NewHorizons.Components.Stars;
 using NewHorizons.External.Modules.VariableSize;
+using NewHorizons.Utility;
+using NewHorizons.Utility.Files;
+using NewHorizons.Utility.OuterWilds;
 using OWML.Common;
 using System.Linq;
-using NewHorizons.Components.Stars;
-using NewHorizons.Utility.OuterWilds;
-using NewHorizons.Utility.Files;
-using NewHorizons.Utility.OWML;
-using UnityEngine.InputSystem.XR;
+using UnityEngine;
 
 namespace NewHorizons.Builder.Body
 {

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -190,6 +190,7 @@ namespace NewHorizons.Builder.Props
                 newDetailGO.transform.parent = prop.transform.parent;
                 newDetailGO.transform.position = prop.transform.position;
                 newDetailGO.transform.rotation = prop.transform.rotation;
+                newDetailGO.transform.localScale = prop.transform.localScale;
 
                 // Can't modify parents while looping through children bc idk
                 var children = new List<Transform>();

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -187,8 +187,9 @@ namespace NewHorizons.Builder.Props
                 // Just swap all the children to a new game object
                 var newDetailGO = new GameObject(prop.name);
                 newDetailGO.SetActive(false);
-                newDetailGO.transform.position = prop.transform.position;
                 newDetailGO.transform.parent = prop.transform.parent;
+                newDetailGO.transform.position = prop.transform.position;
+                newDetailGO.transform.rotation = prop.transform.rotation;
 
                 // Can't modify parents while looping through children bc idk
                 var children = new List<Transform>();

--- a/NewHorizons/Patches/SolarFlareEmitterPatches.cs
+++ b/NewHorizons/Patches/SolarFlareEmitterPatches.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+using System.Linq;
+
+namespace NewHorizons.Patches
+{
+    [HarmonyPatch(typeof(SolarFlareEmitter))]
+    public static class SolarFlareEmitterPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(SolarFlareEmitter.Awake))]
+        public static void SolarFlareEmitter_Awake(SolarFlareEmitter __instance)
+        {
+            // Because in StarBuilder we use inactive game objects instead of real prefabs these objects all get created inactive
+            foreach (var flare in __instance._streamers.Concat(__instance._loops).Concat(__instance._domes))
+            {
+                flare.gameObject.SetActive(true);
+                flare.enabled = true;
+            }
+        }
+    }
+}

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes
- Fix flares turning white in the main system again #668
- Fix rotations of props that used `RemoveComponents`. This won't visibly affect any existing mods, and just makes it so that the rotation shown in Unity Explorer will match what's used in the config.
