### PR TITLE
1.14.4

### DIFF
--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -113,24 +113,24 @@ namespace NewHorizons.Builder.Body
                 if (!_singularitiesByID.TryGetValue(blackHoleID, out GameObject blackHole))
                 {
                     NHLogger.LogWarning($"Black hole [{blackHoleID}] is missing.");
-                    break;
+                    continue;
                 }
                 if (!_singularitiesByID.TryGetValue(whiteHoleID, out GameObject whiteHole))
                 {
                     NHLogger.LogWarning($"White hole [{whiteHoleID}] is missing.");
-                    break;
+                    continue;
                 }
                 var whiteHoleVolume = whiteHole.GetComponentInChildren<WhiteHoleVolume>();
                 var blackHoleVolume = blackHole.GetComponentInChildren<BlackHoleVolume>();
                 if (whiteHoleVolume == null || blackHoleVolume == null)
                 {
                     NHLogger.LogWarning($"Singularities [{blackHoleID}] and [{whiteHoleID}] do not have compatible polarities.");
-                    break;
+                    continue;
                 }
                 if (blackHoleVolume._whiteHole != null && blackHoleVolume._whiteHole != whiteHoleVolume)
                 {
                     NHLogger.LogWarning($"Black hole [{blackHoleID}] has already been linked!");
-                    break;
+                    continue;
                 }
                 NHLogger.LogVerbose($"Pairing singularities [{blackHoleID}], [{whiteHoleID}]");
                 blackHoleVolume._whiteHole = whiteHoleVolume;

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -574,7 +574,7 @@
           "format": "int32",
           "default": 0
         },
-        "addPhysics": {
+        "pushable": {
           "type": "boolean",
           "description": "Apply physics to this planet when you bump into it. Will have a spherical collider the size of surfaceSize. \nFor custom colliders they have to all be convex and you can leave surface size as 0.\nThis is meant for stuff like satellites which are relatively simple and can be de-orbited.\nIf you are using an orbit line but a tracking line, it will be removed when the planet is bumped in to."
         }

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes
- Fix flares turning white in the main system again #668
- Fix rotations of props that used `RemoveComponents`. This won't visibly affect any existing mods, and just makes it so that the rotation shown in Unity Explorer will match what's used in the config.