### PR TITLE
1.14.6

### DIFF
--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -113,24 +113,24 @@ namespace NewHorizons.Builder.Body
                 if (!_singularitiesByID.TryGetValue(blackHoleID, out GameObject blackHole))
                 {
                     NHLogger.LogWarning($"Black hole [{blackHoleID}] is missing.");
-                    break;
+                    continue;
                 }
                 if (!_singularitiesByID.TryGetValue(whiteHoleID, out GameObject whiteHole))
                 {
                     NHLogger.LogWarning($"White hole [{whiteHoleID}] is missing.");
-                    break;
+                    continue;
                 }
                 var whiteHoleVolume = whiteHole.GetComponentInChildren<WhiteHoleVolume>();
                 var blackHoleVolume = blackHole.GetComponentInChildren<BlackHoleVolume>();
                 if (whiteHoleVolume == null || blackHoleVolume == null)
                 {
                     NHLogger.LogWarning($"Singularities [{blackHoleID}] and [{whiteHoleID}] do not have compatible polarities.");
-                    break;
+                    continue;
                 }
                 if (blackHoleVolume._whiteHole != null && blackHoleVolume._whiteHole != whiteHoleVolume)
                 {
                     NHLogger.LogWarning($"Black hole [{blackHoleID}] has already been linked!");
-                    break;
+                    continue;
                 }
                 NHLogger.LogVerbose($"Pairing singularities [{blackHoleID}], [{whiteHoleID}]");
                 blackHoleVolume._whiteHole = whiteHoleVolume;

--- a/NewHorizons/Builder/Body/StellarRemnantBuilder.cs
+++ b/NewHorizons/Builder/Body/StellarRemnantBuilder.cs
@@ -120,7 +120,7 @@ namespace NewHorizons.Builder.Body
             flares.gameObject.transform.localScale = new Vector3(0.85f, 0.85f, 0.85f);
 
             // Add singularity
-            var singularityRenderer = SingularityBuilder.MakeSingularityGraphics(planetGO, true, neutronStarSize, neutronStarSize * 2.5f);
+            var singularityRenderer = SingularityBuilder.MakeSingularityGraphics(neutronStar, true, neutronStarSize, neutronStarSize * 2.5f);
             singularityRenderer.GetComponent<MeshRenderer>().material.color = new Color(0.5f, 2f, 2f, 1f);
 
             return neutronStar;

--- a/NewHorizons/Builder/Volumes/DayNightAudioVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/DayNightAudioVolumeBuilder.cs
@@ -1,6 +1,7 @@
 using NewHorizons.Builder.Props;
 using NewHorizons.Components.Volumes;
 using NewHorizons.External.Modules.Volumes.VolumeInfos;
+using NewHorizons.Utility;
 using NewHorizons.Utility.OuterWilds;
 using OWML.Common;
 using UnityEngine;
@@ -21,6 +22,7 @@ namespace NewHorizons.Builder.Volumes
             audioVolume.nightAudio = info.nightAudio;
             audioVolume.modBehaviour = mod;
             audioVolume.volume = info.volume;
+            audioVolume.SetTrack(info.track.ConvertToOW());
 
             var shape = go.AddComponent<SphereShape>();
             shape.radius = info.radius;

--- a/NewHorizons/Components/Volumes/NHDayNightAudioVolume.cs
+++ b/NewHorizons/Components/Volumes/NHDayNightAudioVolume.cs
@@ -16,6 +16,7 @@ namespace NewHorizons.Components.Volumes
 
         private OWAudioSource _daySource;
         private OWAudioSource _nightSource;
+        private OWAudioMixer.TrackName _track;
 
         private Transform _planetTransform;
         private Transform _sunTransform;
@@ -63,6 +64,8 @@ namespace NewHorizons.Components.Volumes
                 _daySource.spread = 180f;
                 _daySource.dopplerLevel = 0f;
                 _daySource.SetMaxVolume(volume);
+                _daySource.SetTrack(_track);
+                _daySource.loop = true;
                 AudioUtilities.SetAudioClip(_daySource, dayAudio, modBehaviour);
             }
 
@@ -77,6 +80,8 @@ namespace NewHorizons.Components.Volumes
                 _nightSource.spread = 180f;
                 _nightSource.dopplerLevel = 0f;
                 _nightSource.SetMaxVolume(volume);
+                _nightSource.SetTrack(_track);
+                _nightSource.loop = true;
                 AudioUtilities.SetAudioClip(_nightSource, nightAudio, modBehaviour);
             }
         }
@@ -137,6 +142,13 @@ namespace NewHorizons.Components.Volumes
         private bool IsDay()
         {
             return Vector3.Angle(_planetTransform.position - Locator.GetPlayerTransform().position, Locator.GetPlayerTransform().position - _sunTransform.position) < dayWindow * 0.5f;
+        }
+
+        public void SetTrack(OWAudioMixer.TrackName track)
+        {
+            _track = track;
+            _nightSource?.SetTrack(track);
+            _daySource?.SetTrack(track);
         }
     }
 }

--- a/NewHorizons/External/Modules/BaseModule.cs
+++ b/NewHorizons/External/Modules/BaseModule.cs
@@ -79,6 +79,12 @@ namespace NewHorizons.External.Modules
         /// </summary>
         public bool pushable;
 
+        /// <summary>
+        /// Set this to true to have no proxy be generated for this planet. 
+        /// This is a small representation of the planet that appears when it is outside of the regular Unity camera range.
+        /// </summary>
+        public bool hideProxy;
+
         #region Obsolete
 
         [Obsolete("IsSatellite is deprecated, please use ShowMinimap instead")]

--- a/NewHorizons/External/Modules/Volumes/VolumeInfos/DayNightAudioVolumeInfo.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumeInfos/DayNightAudioVolumeInfo.cs
@@ -1,3 +1,4 @@
+using NewHorizons.External.SerializableEnums;
 using Newtonsoft.Json;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -35,5 +36,11 @@ namespace NewHorizons.External.Modules.Volumes.VolumeInfos
         [Range(0f, 1f)]
         [DefaultValue(1f)]
         public float volume = 1f;
+
+        /// <summary>
+        /// The audio track of this audio volume.
+        /// Most of the time you'll use environment (the default) for sound effects and music for music. 
+        /// </summary>
+        [DefaultValue("environment")] public NHAudioMixerTrackName track = NHAudioMixerTrackName.Environment;
     }
 }

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -493,7 +493,7 @@ namespace NewHorizons.Handlers
             var remnant = otherBodies.Where(x => x.Config.isStellarRemnant && x.Config.name == body.Config.name).FirstOrDefault();
             // TODO: add proxies for quantum states
             //var quantumStates = otherBodies.Where(x => x.Config.isQuantumState && x.Config.name == body.Config.name).ToArray();
-            if (!(body.Config.Cloak != null && body.Config.Cloak.radius != 0f))
+            if (!(body.Config.Cloak != null && body.Config.Cloak.radius != 0f) && !body.Config.Base.hideProxy)
             {
                 Delay.FireOnNextUpdate(() =>
                 {

--- a/NewHorizons/Handlers/PlanetDestructionHandler.cs
+++ b/NewHorizons/Handlers/PlanetDestructionHandler.cs
@@ -84,6 +84,9 @@ namespace NewHorizons.Handlers
                 
                 // Since we didn't call RemoveBody on the Stranger have to call this here
                 StrangerRemoved();
+
+                // Don't forget to fix THE WARP BUG
+                DisableBody(SearchUtilities.Find("StreamingGroup_TH"), true);
             }, 2); // Have to wait or shit goes wild
 
             foreach (var streamingAssetBundle in StreamingManager.s_activeBundles)

--- a/NewHorizons/Handlers/TitleSceneHandler.cs
+++ b/NewHorizons/Handlers/TitleSceneHandler.cs
@@ -79,10 +79,19 @@ namespace NewHorizons.Handlers
             // Resize planets relative to each other
             // If there are multiple planets shrink them down to 30% of the size
             var maxSize = planetSizes.Select(x => x.size).Max();
+            var minSize = planetSizes.Select(x => x.size).Min();
             var multiplePlanets = planetSizes.Count > 1;
             foreach (var (planet, size) in planetSizes) 
             {
-                planet.transform.localScale *= (size / maxSize) * (multiplePlanets ? 0.3f : 1f);
+                var adjustedSize = size / maxSize;
+                // If some planets would be too small we'll do a funny thing
+                if (minSize / maxSize < 0.3f)
+                {
+                    var t = Mathf.InverseLerp(minSize, maxSize, size);
+                    adjustedSize = Mathf.Lerp(0.3f, 1f, t * t);
+                }
+
+                planet.transform.localScale *= adjustedSize * (multiplePlanets ? 0.3f : 1f);
             }
         }
 

--- a/NewHorizons/Handlers/TitleSceneHandler.cs
+++ b/NewHorizons/Handlers/TitleSceneHandler.cs
@@ -27,8 +27,8 @@ namespace NewHorizons.Handlers
 
         public static void DisplayBodyOnTitleScreen(List<NewHorizonsBody> bodies)
         {
-            //Try loading one planet why not
-            //var eligible = BodyDict.Values.ToList().SelectMany(x => x).ToList().Where(b => (b.Config.HeightMap != null || b.Config.Atmosphere?.Cloud != null) && b.Config.Star == null).ToArray();
+            // Try loading one planet why not
+            // var eligible = BodyDict.Values.ToList().SelectMany(x => x).ToList().Where(b => (b.Config.HeightMap != null || b.Config.Atmosphere?.Cloud != null) && b.Config.Star == null).ToArray();
             var eligible = bodies.Where(b => (b.Config.HeightMap != null || b.Config.Atmosphere?.clouds != null) && b.Config.Star == null && b.Config.canShowOnTitle).ToArray();
             var eligibleCount = eligible.Count();
             if (eligibleCount == 0) return;
@@ -38,26 +38,29 @@ namespace NewHorizons.Handlers
 
             NHLogger.LogVerbose($"Displaying {selectionCount} bodies on the title screen");
 
-            GameObject body1, body2, body3;
+            var planetSizes = new List<(GameObject planet, float size)>();
 
-            body1 = LoadTitleScreenBody(eligible[indices[0]]);
-            body1.transform.localRotation = Quaternion.Euler(15, 0, 0);
+            var bodyInfo = LoadTitleScreenBody(eligible[indices[0]]);
+            bodyInfo.planet.transform.localRotation = Quaternion.Euler(15, 0, 0);
+            planetSizes.Add(bodyInfo);
+
             if (selectionCount > 1)
             {
-                body1.transform.localScale = Vector3.one * (body1.transform.localScale.x) * 0.3f;
-                body1.transform.localPosition = new Vector3(0, -15, 0);
-                body1.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
-                body2 = LoadTitleScreenBody(eligible[indices[1]]);
-                body2.transform.localScale = Vector3.one * (body2.transform.localScale.x) * 0.3f;
-                body2.transform.localPosition = new Vector3(7, 30, 0);
-                body2.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
+                bodyInfo.planet.transform.localPosition = new Vector3(0, -15, 0);
+                bodyInfo.planet.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
+
+                var bodyInfo2 = LoadTitleScreenBody(eligible[indices[1]]);
+                bodyInfo2.planet.transform.localPosition = new Vector3(7, 30, 0);
+                bodyInfo2.planet.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
+                planetSizes.Add(bodyInfo2);
             }
+
             if (selectionCount > 2)
             {
-                body3 = LoadTitleScreenBody(eligible[indices[2]]);
-                body3.transform.localScale = Vector3.one * (body3.transform.localScale.x) * 0.3f;
-                body3.transform.localPosition = new Vector3(-5, 10, 0);
-                body3.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
+                var bodyInfo3 = LoadTitleScreenBody(eligible[indices[2]]);
+                bodyInfo3.planet.transform.localPosition = new Vector3(-5, 10, 0);
+                bodyInfo3.planet.transform.localRotation = Quaternion.Euler(10f, 0f, 0f);
+                planetSizes.Add(bodyInfo3);
             }
 
             SearchUtilities.Find("Scene/Background/PlanetPivot/Prefab_HEA_Campfire").SetActive(false);
@@ -72,87 +75,72 @@ namespace NewHorizons.Handlers
             light.color = Color.white;
             light.range = float.PositiveInfinity;
             light.intensity = 0.8f;
+
+            // Resize planets relative to each other
+            // If there are multiple planets shrink them down to 30% of the size
+            var maxSize = planetSizes.Select(x => x.size).Max();
+            var multiplePlanets = planetSizes.Count > 1;
+            foreach (var (planet, size) in planetSizes) 
+            {
+                planet.transform.localScale *= (size / maxSize) * (multiplePlanets ? 0.3f : 1f);
+            }
         }
 
-        private static GameObject LoadTitleScreenBody(NewHorizonsBody body)
+        private static (GameObject planet, float size) LoadTitleScreenBody(NewHorizonsBody body)
         {
             NHLogger.LogVerbose($"Displaying {body.Config.name} on the title screen");
             var titleScreenGO = new GameObject(body.Config.name + "_TitleScreen");
 
-            var maxSize = -1f;
+            var maxRadius = -1f;
 
             if (body.Config.HeightMap != null)
             {
                 HeightMapBuilder.Make(titleScreenGO, null, body.Config.HeightMap, body.Mod, 30);
-                maxSize = Mathf.Max(maxSize, body.Config.HeightMap.maxHeight, body.Config.HeightMap.minHeight);
+                maxRadius = Mathf.Max(maxRadius, body.Config.HeightMap.maxHeight, body.Config.HeightMap.minHeight);
             }
+
             if (body.Config.Atmosphere?.clouds?.texturePath != null && body.Config.Atmosphere?.clouds?.cloudsPrefab != CloudPrefabType.Transparent)
             {
-                // Hacky but whatever I just want a sphere
+                // Hacky but whatever I just want a textured sphere
                 var cloudTextureMap = new HeightMapModule();
                 cloudTextureMap.maxHeight = cloudTextureMap.minHeight = body.Config.Atmosphere.size;
                 cloudTextureMap.textureMap = body.Config.Atmosphere.clouds.texturePath;
                 HeightMapBuilder.Make(titleScreenGO, null, cloudTextureMap, body.Mod, 30);
-                maxSize = Mathf.Max(maxSize, cloudTextureMap.maxHeight);
+
+                maxRadius = Mathf.Max(maxRadius, cloudTextureMap.maxHeight);
             }
-            else
+
+            if (body.Config.Base.groundSize > 0f)
             {
-                if (body.Config.Water != null)
+                MakeSphere(titleScreenGO, body.Config.Base.groundSize * 2f);
+                maxRadius = Mathf.Max(maxRadius, body.Config.Base.groundSize);
+            }
+
+            if (body.Config.Water != null)
+            {
+                var waterRadius = MakeWater(body, titleScreenGO);
+                maxRadius = Mathf.Max(maxRadius, waterRadius);
+            }
+
+            if (body.Config.Lava != null)
+            {
+                var lavaRadius = MakeLava(body, titleScreenGO);
+                maxRadius = Mathf.Max(maxRadius, lavaRadius);
+            }
+
+            if (body.Config.Sand != null)
+            {
+                var sandRadius = MakeSand(body, titleScreenGO);
+                maxRadius = Mathf.Max(maxRadius, sandRadius);
+            }
+
+            if (body.Config.Rings != null && body.Config.Rings.Length > 0)
+            {
+                foreach (var ring in body.Config.Rings)
                 {
-                    var waterGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    var size = 2f * body.Config.Water.size * (body.Config.Water.curve?.FirstOrDefault()?.value ?? 1f);
+                    RingBuilder.Make(titleScreenGO, null, ring, body.Mod);
 
-                    waterGO.transform.localScale = Vector3.one * size;
-
-                    var mr = waterGO.GetComponent<MeshRenderer>();
-                    var colour = body.Config.Water.tint?.ToColor() ?? Color.blue;
-                    mr.material.color = new Color(colour.r, colour.g, colour.b, 0.9f);
-
-                    // Make it transparent!
-                    mr.material.SetOverrideTag("RenderType", "Transparent");
-                    mr.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
-                    mr.material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
-                    mr.material.SetInt("_ZWrite", 0);
-                    mr.material.DisableKeyword("_ALPHATEST_ON");
-                    mr.material.DisableKeyword("_ALPHABLEND_ON");
-                    mr.material.EnableKeyword("_ALPHAPREMULTIPLY_ON");
-                    mr.material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
-
-                    waterGO.transform.parent = titleScreenGO.transform;
-                    waterGO.transform.localPosition = Vector3.zero;
-
-                    maxSize = Mathf.Max(maxSize, size);
-                }
-                if (body.Config.Lava != null)
-                {
-                    var lavaGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    var size = 2f * body.Config.Lava.size * (body.Config.Lava.curve?.FirstOrDefault()?.value ?? 1f);
-
-                    lavaGO.transform.localScale = Vector3.one * size;
-
-                    var mr = lavaGO.GetComponent<MeshRenderer>();
-                    mr.material.color = body.Config.Lava.tint?.ToColor() ?? Color.red;
-                    mr.material.SetColor("_EmissionColor", mr.material.color * 2f);
-
-                    lavaGO.transform.parent = titleScreenGO.transform;
-                    lavaGO.transform.localPosition = Vector3.zero;
-
-                    maxSize = Mathf.Max(maxSize, size);
-                }
-                if (body.Config.Sand != null)
-                {
-                    var sandGO = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-                    var size = 2f * body.Config.Sand.size * (body.Config.Sand.curve?.FirstOrDefault()?.value ?? 1f);
-
-                    sandGO.transform.localScale = Vector3.one * size;
-                    var mr = sandGO.GetComponent<MeshRenderer>();
-                    mr.material.color = body.Config.Sand.tint?.ToColor() ?? Color.yellow;
-                    mr.material.SetFloat("_Glossiness", 0);
-
-                    sandGO.transform.parent = titleScreenGO.transform;
-                    sandGO.transform.localPosition = Vector3.zero;
-
-                    maxSize = Mathf.Max(maxSize, size);
+                    maxRadius = Mathf.Max(maxRadius, ring.outerRadius);
                 }
             }
 
@@ -164,21 +152,66 @@ namespace NewHorizons.Handlers
             }
             pivot.name = "Pivot";
 
-            if (body.Config.Rings != null && body.Config.Rings.Length > 0)
-            {
-                foreach (var ring in body.Config.Rings)
-                {
-                    RingBuilder.Make(titleScreenGO, null, ring, body.Mod);
-
-                    maxSize = Mathf.Max(maxSize, ring.outerRadius);
-                }
-            }
-
             titleScreenGO.transform.parent = pivot.transform;
             titleScreenGO.transform.localPosition = Vector3.zero;
-            titleScreenGO.transform.localScale = Vector3.one * 30f / maxSize;
+            titleScreenGO.transform.localScale = Vector3.one * 30f / maxRadius;
 
-            return titleScreenGO;
+            return (titleScreenGO, maxRadius);
+        }
+
+        // Returns radius
+        private static float MakeWater(NewHorizonsBody body, GameObject root)
+        {
+            var diameter = 2f * body.Config.Water.size * (body.Config.Water.curve?.FirstOrDefault()?.value ?? 1f);
+
+            var mr = MakeSphere(root, diameter);
+            var colour = body.Config.Water.tint?.ToColor() ?? Color.blue;
+            mr.material.color = new Color(colour.r, colour.g, colour.b, 0.9f);
+
+            // Make it transparent!
+            mr.material.SetOverrideTag("RenderType", "Transparent");
+            mr.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.One);
+            mr.material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+            mr.material.SetInt("_ZWrite", 0);
+            mr.material.DisableKeyword("_ALPHATEST_ON");
+            mr.material.DisableKeyword("_ALPHABLEND_ON");
+            mr.material.EnableKeyword("_ALPHAPREMULTIPLY_ON");
+            mr.material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+
+            return diameter / 2f;
+        }
+
+        private static float MakeLava(NewHorizonsBody body, GameObject root)
+        {
+            var diameter = 2f * body.Config.Lava.size * (body.Config.Lava.curve?.FirstOrDefault()?.value ?? 1f);
+
+            var mr = MakeSphere(root, diameter);
+            mr.material.color = body.Config.Lava.tint?.ToColor() ?? Color.red;
+            mr.material.SetColor("_EmissionColor", mr.material.color * 2f);
+
+            return diameter / 2f;
+        }
+
+        private static float MakeSand(NewHorizonsBody body, GameObject root)
+        {
+            var diameter = 2f * body.Config.Sand.size * (body.Config.Sand.curve?.FirstOrDefault()?.value ?? 1f);
+
+            var mr = MakeSphere(root, diameter);
+            mr.material.color = body.Config.Sand.tint?.ToColor() ?? Color.yellow;
+            mr.material.SetFloat("_Glossiness", 0);
+
+            return diameter / 2f;
+        }
+
+        private static MeshRenderer MakeSphere(GameObject root, float diameter)
+        {
+            var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            var meshRenderer = sphere.GetComponent<MeshRenderer>();
+            sphere.transform.parent = root.transform;
+            sphere.transform.localPosition = Vector3.zero;
+            sphere.transform.localScale = Vector3.one * diameter;
+
+            return meshRenderer;
         }
     }
 }

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -906,6 +906,11 @@ namespace NewHorizons
             }
             else
             {
+                if (!string.IsNullOrEmpty(_defaultSystemOverride))
+                {
+                    NHLogger.LogError($"The given default system override {_defaultSystemOverride} is invalid - no system exists with that name");
+                }
+
                 _currentStarSystem = _defaultStarSystem;
                 IsWarpingFromShip = false;
             }

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.4",
+  "version": "1.14.5",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "owmlVersion": "2.9.3",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Minor features
- Added `hideProxy` option to Base module. Implements #700 
- Added `track` to day-night audio volumes. Implements #695

## Improvements
- Log error if default system override is invalid. Implements #702 

## Bug fixes
- Fix neutron stars appearing inside of living stars
- Fix first loop immortality after statue pairing. Fixes #703
- Made day-night audio volumes loop. Fixes #695
- Fixed title screen planets with water/sand/lava being sized improperly. Title screen planet sizes reflect their real sizes again. Fixes #678