### PR TITLE
Obsolete pulsars

### DIFF
--- a/NewHorizons/Builder/Body/StellarRemnantBuilder.cs
+++ b/NewHorizons/Builder/Body/StellarRemnantBuilder.cs
@@ -43,11 +43,6 @@ namespace NewHorizons.Builder.Body
                         MakeNeutronStar(go, sector, mod, star.Config.Star);
 
                         break;
-                    case StellarRemnantType.Pulsar:
-                        MakeNeutronStar(go, sector, mod, star.Config.Star);
-                        // TODO: add jets, up rotation speed (use a RotateTransform on the star instead of changing sidereal period)
-
-                        break;
                     case StellarRemnantType.BlackHole:
                         MakeBlackhole(go, sector, star.Config.Star);
 
@@ -145,8 +140,6 @@ namespace NewHorizons.Builder.Body
                 case StellarRemnantType.WhiteDwarf:
                     return MakeWhiteDwarf(planet, null, mod, progenitor, proxy);
                 case StellarRemnantType.NeutronStar:
-                    return MakeNeutronStar(planet, null, mod, progenitor, proxy);
-                case StellarRemnantType.Pulsar:
                     return MakeNeutronStar(planet, null, mod, progenitor, proxy);
                 case StellarRemnantType.BlackHole:
                     return MakeBlackhole(planet, null, progenitor, proxy);

--- a/NewHorizons/External/Configs/PlanetConfig.cs
+++ b/NewHorizons/External/Configs/PlanetConfig.cs
@@ -459,6 +459,9 @@ namespace NewHorizons.External.Configs
             if (Star != null)
             {
                 if (!Star.goSupernova) Star.stellarDeathType = StellarDeathType.None;
+
+                // Gave up on supporting pulsars
+                if (Star.stellarRemnantType == StellarRemnantType.Pulsar) Star.stellarRemnantType = StellarRemnantType.NeutronStar;
             }
 
             // Signals no longer use two different variables for audio

--- a/NewHorizons/External/Modules/VariableSize/StarModule.cs
+++ b/NewHorizons/External/Modules/VariableSize/StarModule.cs
@@ -154,7 +154,7 @@ namespace NewHorizons.External.Modules.VariableSize
         [EnumMember(Value = @"default")] Default,
         [EnumMember(Value = @"whiteDwarf")] WhiteDwarf,
         [EnumMember(Value = @"neutronStar")] NeutronStar,
-        [EnumMember(Value = @"pulsar")] Pulsar,
+        [Obsolete] Pulsar,
         [EnumMember(Value = @"blackHole")] BlackHole,
         [EnumMember(Value = @"custom")] Custom
     }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -3507,7 +3507,6 @@
         "Default",
         "WhiteDwarf",
         "NeutronStar",
-        "Pulsar",
         "BlackHole",
         "Custom"
       ],
@@ -3515,7 +3514,6 @@
         "default",
         "whiteDwarf",
         "neutronStar",
-        "pulsar",
         "blackHole",
         "custom"
       ]

--- a/SchemaExporter/SchemaExporter.cs
+++ b/SchemaExporter/SchemaExporter.cs
@@ -88,6 +88,8 @@ public static class SchemaExporter
                     schema.Definitions["NomaiTextType"].EnumerationNames.Remove("CairnVariant");
                     schema.Definitions["QuantumGroupType"].Enumeration.Remove("FailedValidation");
                     schema.Definitions["QuantumGroupType"].EnumerationNames.Remove("FailedValidation");
+                    schema.Definitions["StellarRemnantType"].Enumeration.Remove("Pulsar");
+                    schema.Definitions["StellarRemnantType"].EnumerationNames.Remove("Pulsar");
                     break;
                 case "Star System Schema":
                     schema.Definitions["NomaiCoordinates"].Properties["x"].UniqueItems = true;


### PR DESCRIPTION
## Bug fixes
- Pulsar's are obsolete now because NH is done. Backwards compat will leave them as neutron stars.
