### PR TITLE
allow ghosts to work in bundles maybe

### DIFF
--- a/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
@@ -2,6 +2,7 @@ using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
 using NewHorizons.Utility;
 using UnityEngine;
+
 namespace NewHorizons.Builder.Atmosphere
 {
     public static class EffectsBuilder
@@ -55,29 +56,19 @@ namespace NewHorizons.Builder.Atmosphere
         {
             InitPrefabs();
 
-            GameObject effectsGO = new GameObject("Effects");
+            var effectsGO = new GameObject("Effects");
             effectsGO.SetActive(false);
             effectsGO.transform.parent = sector?.transform ?? planetGO.transform;
             effectsGO.transform.position = planetGO.transform.position;
 
-            SectorCullGroup SCG = effectsGO.AddComponent<SectorCullGroup>();
-            SCG._sector = sector;
-            SCG._particleSystemSuspendMode = CullGroup.ParticleSystemSuspendMode.Stop;
-            SCG._occlusionCulling = false;
-            SCG._dynamicCullingBounds = false;
-            SCG._waitForStreaming = false;
+            var sectorCullGroup = effectsGO.AddComponent<SectorCullGroup>();
+            sectorCullGroup._sector = sector;
+            sectorCullGroup._particleSystemSuspendMode = CullGroup.ParticleSystemSuspendMode.Stop;
+            sectorCullGroup._occlusionCulling = false;
+            sectorCullGroup._dynamicCullingBounds = false;
+            sectorCullGroup._waitForStreaming = false;
 
-            var minHeight = config.Base.surfaceSize;
-            if (config.HeightMap?.minHeight != null)
-            {
-                if (config.Water?.size >= config.HeightMap.minHeight) minHeight = config.Water.size; // use sea level if its higher
-                else minHeight = config.HeightMap.minHeight;
-            }
-            else if (config.Water?.size != null) minHeight = config.Water.size;
-            else if (config.Lava?.size != null) minHeight = config.Lava.size;
-
-            var maxHeight = config.Atmosphere.size;
-            if (config.Atmosphere.clouds?.outerCloudRadius != null) maxHeight = config.Atmosphere.clouds.outerCloudRadius;
+            var (minHeight, maxHeight) = GetDefaultHeightRange(config);
 
             foreach (var particleField in config.ParticleFields)
             {
@@ -129,6 +120,49 @@ namespace NewHorizons.Builder.Atmosphere
                 ParticleFieldModule.ParticleFieldType.Current => _currentEmitterPrefab,
                 _ => null,
             };
+        }
+
+        private static (float, float) GetDefaultHeightRange(PlanetConfig config)
+        {
+            // Determining default values for min/max height
+            var minHeight = 0f;
+
+            if (config.HeightMap?.minHeight != null)
+            {
+                if (config.Water?.size >= config.HeightMap.minHeight) minHeight = config.Water.size; // use sea level if its higher
+                else minHeight = config.HeightMap.minHeight;
+            }
+            else if (config.Water?.size != null)
+            {
+                minHeight = config.Water.size;
+            }
+            else if (config.Lava?.size != null)
+            {
+                minHeight = config.Lava.size;
+            }
+            else if (config.Base != null)
+            {
+                minHeight = config.Base.surfaceSize;
+            }
+
+            var maxHeight = 100f;
+            if (config.Atmosphere != null)
+            {
+                if (config.Atmosphere.clouds?.outerCloudRadius != null)
+                {
+                    maxHeight = config.Atmosphere.clouds.outerCloudRadius;
+                }
+                else
+                {
+                    maxHeight = config.Atmosphere.size;
+                }
+            }
+            else if (config.Base != null)
+            {
+                maxHeight = config.Base.surfaceSize * 2f;
+            }
+
+            return (minHeight, maxHeight);
         }
     }
 }

--- a/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/EffectsBuilder.cs
@@ -124,7 +124,6 @@ namespace NewHorizons.Builder.Atmosphere
 
         private static (float, float) GetDefaultHeightRange(PlanetConfig config)
         {
-            // Determining default values for min/max height
             var minHeight = 0f;
 
             if (config.HeightMap?.minHeight != null)
@@ -146,6 +145,7 @@ namespace NewHorizons.Builder.Atmosphere
             }
 
             var maxHeight = 100f;
+
             if (config.Atmosphere != null)
             {
                 if (config.Atmosphere.clouds?.outerCloudRadius != null)
@@ -157,9 +157,9 @@ namespace NewHorizons.Builder.Atmosphere
                     maxHeight = config.Atmosphere.size;
                 }
             }
-            else if (config.Base != null)
+            else if (minHeight != 0f)
             {
-                maxHeight = config.Base.surfaceSize * 2f;
+                maxHeight = minHeight * 2f;
             }
 
             return (minHeight, maxHeight);

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -339,10 +339,12 @@ namespace NewHorizons.Builder.Props
                     component.gameObject.layer = Layer.IgnoreSun;
                 }
             }
-            // I forget why this is here
+            // Else it spams a ton of NRE, happens when you try to put a non-hostile Ghostbird 
             else if (component is GhostIK or GhostEffects)
             {
-                UnityEngine.Object.DestroyImmediate(component);
+                // For when somebody (pikmin) makes a Unity ghost bird
+                if (component.transform.parent.GetComponent<GhostBrain>() == null)
+                    UnityEngine.Object.DestroyImmediate(component);
                 return;
             }
             else if (component is DarkMatterVolume)

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -97,6 +97,7 @@ namespace NewHorizons
 
         private bool _playerAwake;
         public bool PlayerSpawned { get; set; }
+        public bool ForceClearCaches { get; set; } // for reloading configs
 
         public ShipWarpController ShipWarpController { get; private set; }
 
@@ -196,7 +197,6 @@ namespace NewHorizons
                 }
             };
 
-            // why is this false when called in Start
             if (resetTranslation)
             {
                 TranslationHandler.ClearTables();
@@ -289,8 +289,10 @@ namespace NewHorizons
             EnumUtilities.ClearCache();
 
             // Caches of other assets only have to be cleared if we changed star systems
-            if (CurrentStarSystem != _previousStarSystem)
+            if (ForceClearCaches || CurrentStarSystem != _previousStarSystem)
             {
+                ForceClearCaches = false;
+                
                 NHLogger.Log($"Changing star system from {_previousStarSystem} to {CurrentStarSystem} - Clearing system-specific caches!");
                 ImageUtilities.ClearCache();
                 AudioUtilities.ClearCache();

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -196,6 +196,7 @@ namespace NewHorizons
                 }
             };
 
+            // why is this false when called in Start
             if (resetTranslation)
             {
                 TranslationHandler.ClearTables();

--- a/NewHorizons/Utility/DebugTools/DebugReload.cs
+++ b/NewHorizons/Utility/DebugTools/DebugReload.cs
@@ -50,7 +50,7 @@ namespace NewHorizons.Utility.DebugTools
 
             Main.Instance.ChangeCurrentStarSystem(Main.Instance.CurrentStarSystem);
             
-            NHLogger.Log($"Reloading star system {Main.Instance.CurrentStarSystem} - Clearing system-specific caches!");
+            NHLogger.Log($"Reloading configs for star system {Main.Instance.CurrentStarSystem} - Clearing system-specific caches!");
             ImageUtilities.ClearCache();
             AudioUtilities.ClearCache();
             AssetBundleUtilities.ClearCache();

--- a/NewHorizons/Utility/DebugTools/DebugReload.cs
+++ b/NewHorizons/Utility/DebugTools/DebugReload.cs
@@ -1,4 +1,5 @@
 using NewHorizons.Handlers;
+using NewHorizons.Utility.Files;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
 using OWML.Common.Menus;
@@ -48,6 +49,11 @@ namespace NewHorizons.Utility.DebugTools
             SearchUtilities.Find("/PauseMenu/PauseMenuManagers").GetComponent<PauseMenuManager>().OnSkipToNextTimeLoop();
 
             Main.Instance.ChangeCurrentStarSystem(Main.Instance.CurrentStarSystem);
+            
+            NHLogger.Log($"Reloading star system {Main.Instance.CurrentStarSystem} - Clearing system-specific caches!");
+            ImageUtilities.ClearCache();
+            AudioUtilities.ClearCache();
+            AssetBundleUtilities.ClearCache();
 
             Main.SecondsElapsedInLoop = -1f;
         }

--- a/NewHorizons/Utility/DebugTools/DebugReload.cs
+++ b/NewHorizons/Utility/DebugTools/DebugReload.cs
@@ -48,12 +48,8 @@ namespace NewHorizons.Utility.DebugTools
 
             SearchUtilities.Find("/PauseMenu/PauseMenuManagers").GetComponent<PauseMenuManager>().OnSkipToNextTimeLoop();
 
+            Main.Instance.ForceClearCaches = true;
             Main.Instance.ChangeCurrentStarSystem(Main.Instance.CurrentStarSystem);
-            
-            NHLogger.Log($"Reloading configs for star system {Main.Instance.CurrentStarSystem} - Clearing system-specific caches!");
-            ImageUtilities.ClearCache();
-            AudioUtilities.ClearCache();
-            AssetBundleUtilities.ClearCache();
 
             Main.SecondsElapsedInLoop = -1f;
         }


### PR DESCRIPTION
<!-- A new module or something else important -->
## Major features
-

<!-- A new parameter added to a module, or API feature -->
## Minor features
-

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->
## Improvements
- Ghost animator components don't always get removed now (except when they need to be)

<!-- Be sure to reference the existing issue if it exists -->
## Bug fixes
- fix bug where ParticleFields assumes you have an Atmosphere and fails to build your planet if you dont
- Reload configs always reload bundles now