### PR TITLE
Bramble Fixes

### DIFF
--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -235,7 +235,11 @@ namespace NewHorizons.Builder.Props
             // account for scale (this will fix the issue with screen fog caused by scaled down nodes)
 
             // Set the main scale
-            brambleNode.transform.localScale = Vector3.one * config.scale;
+            // Can't just use localScale of root, that makes the preview fog lights get pulled in too much
+            foreach(Transform child in brambleNode.transform)
+            {
+                child.localScale = Vector3.one * config.scale;
+            }
             innerFogWarpVolume._warpRadius *= config.scale;
             innerFogWarpVolume._exitRadius *= config.scale;
 

--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -263,7 +263,7 @@ namespace NewHorizons.Builder.Props
                 // (it's also located on a different child path, so the below FindChild calls wouldn't work)
                 // Default size is 70
                 var fog = brambleNode.FindChild("Effects/InnerWarpFogSphere");
-                fog.transform.localScale = Vector3.one * config.scale * 70f;
+                //fog.transform.localScale = Vector3.one * config.scale * 70f; This is already scaled by its parent, don't know why we scale it again
 
                 // Copy shared material to not be shared
                 var fogRenderer = fog.GetComponent<MeshRenderer>();


### PR DESCRIPTION
<!-- Be sure to reference the existing issue if it exists -->
## Bug fixes
- Fixed a bug where fog preview lights were being affected too much by node scaling (cause of #574)
- Fixed an issue where fog of bramble nodes was being double scaled (maybe caused by c9ee5ec1ac38a7ad9b5b9c4c7329ec526bf8cace)

I included a planet folder that adds a little node orbiting DB. That node should be able to demonstrate the old & new behaviors.
[planets.zip](https://github.com/Outer-Wilds-New-Horizons/new-horizons/files/12629245/planets.zip)
