### PR TITLE
Stop propagated signals from having a detection area

### DIFF
--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -402,6 +402,11 @@ namespace NewHorizons.Builder.Props
                     signalGO.GetComponent<AudioSignal>()._sourceRadius = 1;
                     signalGO.transform.position = brambleNode.transform.position;
                     signalGO.transform.parent = brambleNode.transform;
+
+                    //Don't need the unknown signal detection bits
+                    Component.Destroy(signalGO.GetComponent<AudioSignalDetectionTrigger>());
+                    Component.Destroy(signalGO.GetComponent<OWTriggerVolume>());
+                    Component.Destroy(signalGO.GetComponent<SphereShape>());
                 }
             }
 


### PR DESCRIPTION
<!-- Be sure to reference the existing issue if it exists -->

## Bug fixes

- Fixed an issue where Bramble-propagated signals would have a detection area.

[planets.zip](https://github.com/Outer-Wilds-New-Horizons/new-horizons/files/13880774/planets.zip)
The attached file puts a bramble node near the Hearthian Village that demonstrates the different behaviors.
