### PR TITLE
Exhibitions in the museum on the Eye correctly reflects shiplog

### DIFF
--- a/NewHorizons/Patches/ShipLogPatches/ShipLogManagerPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogManagerPatches.cs
@@ -29,7 +29,7 @@ namespace NewHorizons.Patches.ShipLogPatches
 
             NHLogger.Log($"Beginning Ship Log Generation For: {currentStarSystem}");
 
-            if (currentStarSystem != "SolarSystem")
+            if (currentStarSystem != "SolarSystem" && currentStarSystem != "EyeOfTheUniverse")
             {
                 __instance._shipLogXmlAssets = new TextAsset[] { };
                 foreach (ShipLogEntryLocation logEntryLocation in Object.FindObjectsOfType<ShipLogEntryLocation>())


### PR DESCRIPTION
<!-- Be sure to reference the existing issue if it exists -->

## Bug fixes

- Exhibitions in the museum on the Eye correctly reflects shiplog
    - By avoiding to make shiplog empty when arriving at the eye as in solarsystem.

