### PR TITLE
1.18.6

### DIFF
--- a/NewHorizons/External/NewHorizonBody.cs
+++ b/NewHorizons/External/NewHorizonBody.cs
@@ -28,11 +28,20 @@ namespace NewHorizons.External
 
         public bool RequiresDLC()
         {
-            var detailPaths = Config.Props.details.Select(x => x.path);
-            return Config.Cloak != null 
-                || Config.Props?.rafts != null 
-                || Config.Props?.slideShows != null 
-                || detailPaths.Any(x => x.StartsWith("RingWorld_Body") || x.StartsWith("DreamWorld_Body"));
+            try
+            {
+                var detailPaths = Config?.Props?.details?.Select(x => x.path) ?? Array.Empty<string>();
+                return Config?.Cloak != null
+                    || Config?.Props?.rafts != null
+                    || Config?.Props?.slideShows != null
+                    || detailPaths.Any(x => x.StartsWith("RingWorld_Body") || x.StartsWith("DreamWorld_Body"));
+            }
+            catch
+            {
+                NHLogger.LogWarning($"Failed to check if {Mod.ModHelper.Manifest.Name} requires the DLC");
+                return false;
+            }
+
         }
 
         #region Cache

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -735,6 +735,12 @@ namespace NewHorizons
 
             var addonConfig = mod.ModHelper.Storage.Load<AddonConfig>(file, false);
 
+            if (addonConfig == null)
+            {
+                NHLogger.LogError($"Addon manifest for {mod.ModHelper.Manifest.Name} could not load, check your JSON");
+                return;
+            }
+
             if (addonConfig.achievements != null)
             {
                 AchievementHandler.RegisterAddon(addonConfig, mod as ModBehaviour);

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -110,7 +110,12 @@ namespace NewHorizons
         public StarSystemEvent OnStarSystemLoaded = new();
         public StarSystemEvent OnPlanetLoaded = new();
 
-        public static bool HasDLC { get => EntitlementsManager.IsDlcOwned() == EntitlementsManager.AsyncOwnershipStatus.Owned; }
+        /// <summary>
+        /// Depending on platform, the AsyncOwnershipStatus might not be ready by the time we go to check it.
+        /// If that happens, I guess we just have to assume they do own the DLC.
+        /// Better to false positive than false negative and annoy people every time they launch the game when they do own the DLC
+        /// </summary>
+        public static bool HasDLC { get => EntitlementsManager.IsDlcOwned() != EntitlementsManager.AsyncOwnershipStatus.NotOwned; }
 
         public static StarSystemConfig GetCurrentSystemConfig => SystemDict[Instance.CurrentStarSystem].Config;
 

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, clay, MegaPiggy, John, Trifid, Hawkbar, Book",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.18.5",
+  "version": "1.18.6",
   "owmlVersion": "2.9.8",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes
- Fix NRE when checking for DLC requirement, don't write warning prompt for false positives.
- Log error if addon-manifest.json contains errors
