### PR TITLE
1.18.8

### DIFF
--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -192,7 +192,7 @@ namespace NewHorizons
                 Config =
                 {
                     destroyStockPlanets = false,
-                    factRequiredForWarp = "OPC_EYE_COORDINATES_X1",
+                    //factRequiredForWarp = "OPC_EYE_COORDINATES_X1",
                     Vessel = new StarSystemConfig.VesselModule()
                     {
                         coords = new StarSystemConfig.NomaiCoordinates
@@ -201,7 +201,8 @@ namespace NewHorizons
                             y = new int[4] { 3, 0, 1, 4 },
                             z = new int[6] { 1, 2, 3, 0, 5, 4 }
                         }
-                    }
+                    },
+                    canEnterViaWarpDrive = false
                 }
             };
 


### PR DESCRIPTION
## Bug fixes
- Default to automatic map mode positioning when mixing manual and automatic (would just break before)
- Account for map mode image scale when automatically positioning
- How long could you use your ship warp drive to just go to the eye?!?!?!?! How did I never notice this????? Nobody reported this???? Me when I install signals+ and then the game goes "hey wanna just jump to the end of the game"????????? What?!?!!?!?!?!?!?!?!?!!!!!!!!!! AHHHHHHHHHHHHHHHHH!!!!