### PR TITLE
Check for null refs inside streaming warp volume then destroy it

### DIFF
--- a/NewHorizons/Components/Volumes/StreamingWarpVolume.cs
+++ b/NewHorizons/Components/Volumes/StreamingWarpVolume.cs
@@ -31,14 +31,14 @@ namespace NewHorizons.Components.Volumes
                 if (_probe == null)
                 {
                     NHLogger.LogError($"How is your scout probe null? Destroying {nameof(StreamingWarpVolume)}");
-                    Component.DestroyImmediate(this);
+                    GameObject.DestroyImmediate(gameObject);
                 }
             }
 
             if (streamingGroup == null)
             {
                 NHLogger.LogError($"{nameof(StreamingWarpVolume)} has no streaming group. Destroying {nameof(StreamingWarpVolume)}");
-                Component.DestroyImmediate(this);
+                GameObject.DestroyImmediate(gameObject);
             }
 
             bool probeActive = _probe.IsLaunched() && !_probe.IsAnchored();

--- a/NewHorizons/Components/Volumes/StreamingWarpVolume.cs
+++ b/NewHorizons/Components/Volumes/StreamingWarpVolume.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Utility.OWML;
 using UnityEngine;
 
 namespace NewHorizons.Components.Volumes
@@ -23,6 +24,23 @@ namespace NewHorizons.Components.Volumes
 
         public void FixedUpdate()
         {
+            // Bug report on Astral Codec mod page - Huge lag inside streaming warp volume, possible NRE?
+            if (_probe == null)
+            {
+                _probe = Locator.GetProbe();
+                if (_probe == null)
+                {
+                    NHLogger.LogError($"How is your scout probe null? Destroying {nameof(StreamingWarpVolume)}");
+                    Component.DestroyImmediate(this);
+                }
+            }
+
+            if (streamingGroup == null)
+            {
+                NHLogger.LogError($"{nameof(StreamingWarpVolume)} has no streaming group. Destroying {nameof(StreamingWarpVolume)}");
+                Component.DestroyImmediate(this);
+            }
+
             bool probeActive = _probe.IsLaunched() && !_probe.IsAnchored();
 
             bool shouldBeLoadingRequiredAssets = _playerInVolume || (_probeInVolume && probeActive);


### PR DESCRIPTION
Context is a guy reported the Codec black hole lagging their game, I imagine it could be because of this but I couldn't reproduce it and have no idea what would cause any of these things to be null.

## Bug fixes
- Fix possible lag when near black holes
