### PR TITLE
Add sphere collider to custom items

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -171,6 +171,11 @@ namespace NewHorizons.Builder.Props
             if (detail.item != null)
             {
                 ItemBuilder.MakeItem(prop, go, sector, detail.item, mod);
+                isItem = true;
+                if (detail.hasPhysics)
+                {
+                    NHLogger.LogWarning($"An item with the path {detail.path} has both '{nameof(DetailInfo.hasPhysics)}' and '{nameof(DetailInfo.item)}' set. This will usually result in undesirable behavior.");
+                }
             }
 
             if (detail.itemSocket != null)

--- a/NewHorizons/Builder/Props/ItemBuilder.cs
+++ b/NewHorizons/Builder/Props/ItemBuilder.cs
@@ -79,6 +79,12 @@ namespace NewHorizons.Builder.Props
             item.ClearPickupConditionOnDrop = info.clearPickupConditionOnDrop;
             item.PickupFact = info.pickupFact;
 
+            if (info.colliderRadius > 0f)
+            {
+                go.AddComponent<SphereCollider>().radius = info.colliderRadius;
+                go.GetAddComponent<OWCollider>();
+            }
+
             Delay.FireOnNextUpdate(() =>
             {
                 if (item != null && !string.IsNullOrEmpty(info.pathToInitialSocket))

--- a/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
+++ b/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
@@ -19,13 +19,18 @@ namespace NewHorizons.External.Modules.Props.Item
         /// </summary>
         public string name;
         /// <summary>
-        /// The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCode, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name.
+        /// The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCore, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name.
         /// </summary>
         public string itemType;
         /// <summary>
         /// The furthest distance where the player can interact with this item. Defaults to two meters, same as most vanilla items. Set this to zero to disable all interaction by default.
         /// </summary>
         [DefaultValue(2f)] public float interactRange = 2f;
+        /// <summary>
+        /// The radius that the added sphere collider will use for collision and hover detection.
+        /// If there's already a collider on the detail, you can make this 0.
+        /// </summary>
+        [DefaultValue(0.5f)] public float colliderRadius = 0.5f;
         /// <summary>
         /// Whether the item can be dropped. Defaults to true.
         /// </summary>

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1402,13 +1402,19 @@
         },
         "itemType": {
           "type": "string",
-          "description": "The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCode, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name."
+          "description": "The type of the item, which determines its orientation when held and what sockets it fits into. This can be a custom string, or a vanilla ItemType (Scroll, WarpCore, SharedStone, ConversationStone, Lantern, SlideReel, DreamLantern, or VisionTorch). Defaults to the item name."
         },
         "interactRange": {
           "type": "number",
           "description": "The furthest distance where the player can interact with this item. Defaults to two meters, same as most vanilla items. Set this to zero to disable all interaction by default.",
           "format": "float",
           "default": 2.0
+        },
+        "colliderRadius": {
+          "type": "number",
+          "description": "The radius that the added sphere collider will use for collision and hover detection.\nIf there's already a collider on the detail, you can make this 0.",
+          "format": "float",
+          "default": 0.5
         },
         "droppable": {
           "type": "boolean",


### PR DESCRIPTION
## Minor features
- Added `colliderRadius` to custom items. All custom items will be given a collider for cursor/hover detection unless this is set to 0.
## Bug fixes
- Fixed some edge cases in collision detection with custom items.