### PR TITLE
1.19.3

### DIFF
--- a/NewHorizons/Builder/Body/StarBuilder.cs
+++ b/NewHorizons/Builder/Body/StarBuilder.cs
@@ -408,10 +408,15 @@ namespace NewHorizons.Builder.Body
                 if (starModule.endTint != null)
                 {
                     var endColour = starModule.endTint.ToColor();
-                    darkenedColor = new Color(endColour.r * modifier, endColour.g * modifier, endColour.b * modifier);
+                    var adjustedEndColour = new Color(endColour.r * modifier, endColour.g * modifier, endColour.b * modifier);
+                    Color.RGBToHSV(adjustedEndColour, out var hEnd, out var sEnd, out var vEnd);
+                    var darkenedEndColor = Color.HSVToRGB(hEnd, sEnd * 1.2f, vEnd * 0.1f);
+                    surface.sharedMaterial.SetTexture(ColorRamp, ImageUtilities.LerpGreyscaleImageAlongX(_colorOverTime, adjustedColour, darkenedColor, adjustedEndColour, darkenedEndColor));
                 }
-
-                surface.sharedMaterial.SetTexture(ColorRamp, ImageUtilities.LerpGreyscaleImage(_colorOverTime, adjustedColour, darkenedColor));
+                else
+                {
+                    surface.sharedMaterial.SetTexture(ColorRamp, ImageUtilities.LerpGreyscaleImage(_colorOverTime, adjustedColour, darkenedColor));
+                }
             }
 
             if (!string.IsNullOrEmpty(starModule.starRampTexture))

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -142,6 +142,13 @@ namespace NewHorizons.Builder.Props
                             FixSectoredComponent(component, sector, existingSectors, detail.keepLoaded);
                         }
 
+                        // Asset bundle is a real string -> Object loaded from unity
+                        // If they're adding dialogue we have to manually register the xml text
+                        if (!string.IsNullOrEmpty(detail.assetBundle) && component is CharacterDialogueTree dialogue)
+                        {
+                            DialogueBuilder.AddTranslation(dialogue._xmlCharacterDialogueAsset.text, null);
+                        }
+
                         FixComponent(component, go, detail.ignoreSun);
                     }
                     catch(Exception e)

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -376,7 +376,7 @@ namespace NewHorizons.Builder.Props
             }
         }
 
-        private static void AddTranslation(string xml, string characterName = null)
+        public static void AddTranslation(string xml, string characterName = null)
         {
             var xmlDocument = new XmlDocument();
             xmlDocument.LoadXml(xml);

--- a/NewHorizons/Handlers/TranslationHandler.cs
+++ b/NewHorizons/Handlers/TranslationHandler.cs
@@ -57,7 +57,7 @@ namespace NewHorizons.Handlers
                     return translatedText;
                 }
                 // Try without whitespace if its missing
-                else if (table.TryGetValue(text.TruncateWhitespace(), out translatedText))
+                else if (table.TryGetValue(text.TruncateWhitespaceAndToLower(), out translatedText))
                 {
                     return translatedText;
                 }
@@ -99,7 +99,7 @@ namespace NewHorizons.Handlers
                     // Fix new lines in dialogue translations, remove whitespace from keys else if the dialogue has weird whitespace and line breaks it gets really annoying
                     // to write translation keys for (can't just copy paste out of xml, have to start adding \\n and \\r and stuff
                     // If any of these issues become relevant to other dictionaries we can bring this code over, but for now why fix what isnt broke
-                    var key = originalKey.Replace("\\n", "\n").TruncateWhitespace().Replace("&lt;", "<").Replace("&gt;", ">").Replace("<![CDATA[", "").Replace("]]>", "");
+                    var key = originalKey.Replace("\\n", "\n").Replace("&lt;", "<").Replace("&gt;", ">").Replace("<![CDATA[", "").Replace("]]>", "").TruncateWhitespaceAndToLower();
                     var value = config.DialogueDictionary[originalKey].Replace("\\n", "\n").Replace("&lt;", "<").Replace("&gt;", ">").Replace("<![CDATA[", "").Replace("]]>", "");
 
                     if (!_dialogueTranslationDictionary[language].ContainsKey(key)) _dialogueTranslationDictionary[language].Add(key, value);

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -297,6 +297,40 @@ namespace NewHorizons.Utility.Files
             return newImage;
         }
 
+        public static Color LerpColor(Color start, Color end, float amount)
+        {
+            return new Color(Mathf.Lerp(start.r, end.r, amount), Mathf.Lerp(start.g, end.g, amount), Mathf.Lerp(start.b, end.b, amount));
+        }
+
+        public static Texture2D LerpGreyscaleImageAlongX(Texture2D image, Color lightTintStart, Color darkTintStart, Color lightTintEnd, Color darkTintEnd)
+        {
+            var key = $"{image.name} > lerp greyscale {lightTintStart} {darkTintStart} {lightTintEnd} {darkTintEnd}";
+            if (_textureCache.TryGetValue(key, out var existingTexture)) return (Texture2D)existingTexture;
+
+            var pixels = image.GetPixels();
+            for (int i = 0; i < pixels.Length; i++)
+            {
+                var amount = (i % image.width) / (float) image.width;
+                var lightTint = LerpColor(lightTintStart, lightTintEnd, amount);
+                var darkTint = LerpColor(darkTintStart, darkTintEnd, amount);
+
+                pixels[i].r = Mathf.Lerp(darkTint.r, lightTint.r, pixels[i].r);
+                pixels[i].g = Mathf.Lerp(darkTint.g, lightTint.g, pixels[i].g);
+                pixels[i].b = Mathf.Lerp(darkTint.b, lightTint.b, pixels[i].b);
+            }
+
+            var newImage = new Texture2D(image.width, image.height, image.format, image.mipmapCount != 1);
+            newImage.name = key;
+            newImage.SetPixels(pixels);
+            newImage.Apply();
+
+            newImage.wrapMode = image.wrapMode;
+
+            _textureCache.Add(key, newImage);
+
+            return newImage;
+        }
+
         public static Texture2D ClearTexture(int width, int height, bool wrap = false)
         {
             var key = $"Clear {width} {height} {wrap}";

--- a/NewHorizons/Utility/NewHorizonExtensions.cs
+++ b/NewHorizons/Utility/NewHorizonExtensions.cs
@@ -351,7 +351,7 @@ namespace NewHorizons.Utility
             return parentNode.ChildNodes.Cast<XmlNode>().First(node => node.LocalName == tagName);
         }
 
-        public static string TruncateWhitespace(this string text)
+        public static string TruncateWhitespaceAndToLower(this string text)
         {
             // return Regex.Replace(text.Trim(), @"[^\S\r\n]+", "GUH");
             return Regex.Replace(text.Trim(), @"\s+", " ").ToLowerInvariant();

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "owmlVersion": "2.9.8",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "owmlVersion": "2.9.8",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "owmlVersion": "2.9.8",
   "dependencies": [ "JohnCorby.VanillaFix", "_nebula.MenuFramework", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Improvements
- CharacterDialogueTrees from a Unity asset bundle will now load properly and have translations supported

## Bug fixes
- Sector cull groups now function properly (not erroneously enabled even without KeepLoaded) (fix #792)
- Fixes a problem where projected slides are brighter than the source image (fix #755)
