### PR TITLE
Fix SectorCullGroup on details

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -303,17 +303,6 @@ namespace NewHorizons.Builder.Props
                 s.SetParentSector(sector);
             }
 
-            else if (component is SectorCullGroup sectorCullGroup)
-            {
-                sectorCullGroup._controllingProxy = null;
-                
-                // fixes sector cull group deactivating renderers on map view enter and fast foward
-                // TODO: does this actually work? what? how?
-                sectorCullGroup._inMapView = false;
-                sectorCullGroup._isFastForwarding = false;
-                sectorCullGroup.SetVisible(sectorCullGroup.ShouldBeVisible(), true, false);
-            }
-
             else if(component is SectoredMonoBehaviour behaviour && !existingSectors.Contains(behaviour._sector))
             {
                 // not using SetSector here because it registers the events twice

--- a/NewHorizons/External/Modules/Props/DetailInfo.cs
+++ b/NewHorizons/External/Modules/Props/DetailInfo.cs
@@ -54,7 +54,9 @@ namespace NewHorizons.External.Modules.Props
         public string quantumGroupID;
 
         /// <summary>
-        /// Should this detail stay loaded even if you're outside the sector (good for very large props)
+        /// Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?
+        /// Also makes this detail visible on the map.
+        /// Most logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided.
         /// </summary>
         public bool keepLoaded;
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1342,7 +1342,7 @@
         },
         "keepLoaded": {
           "type": "boolean",
-          "description": "Should this detail stay loaded even if you're outside the sector (good for very large props)"
+          "description": "Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?\nAlso makes this detail visible on the map.\nMost logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided."
         },
         "hasPhysics": {
           "type": "boolean",

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -95,6 +95,10 @@ namespace NewHorizons.Utility.Files
             _textureCache.Clear();
         }
 
+        /// <summary>
+        /// used specifically for projected slides.
+        /// also adds a border (to prevent weird visual bug) and makes the texture linear (otherwise the projected image is too bright).
+        /// </summary>
         public static Texture2D Invert(Texture2D texture)
         {
             var key = $"{texture.name} > invert";
@@ -122,7 +126,7 @@ namespace NewHorizons.Utility.Files
                 }
             }
 
-            var newTexture = new Texture2D(texture.width, texture.height, texture.format, texture.mipmapCount != 1);
+            var newTexture = new Texture2D(texture.width, texture.height, texture.format, texture.mipmapCount != 1, true);
             newTexture.name = key;
             newTexture.SetPixels(pixels);
             newTexture.Apply();


### PR DESCRIPTION
## Bug fixes
- sector cull groups now function properly (not erroneously enabled even without keeploaded) (fix #792)
- fixes a problem where projected slides are brighter than the source image (fix #755)
