### PR TITLE
1.19.5

### DIFF
--- a/NewHorizons/Builder/Atmosphere/FogBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/FogBuilder.cs
@@ -1,10 +1,10 @@
 using NewHorizons.External.Modules;
-using NewHorizons.External.Modules.Props;
 using NewHorizons.Utility;
 using NewHorizons.Utility.Files;
 using OWML.Common;
 using System;
 using UnityEngine;
+
 namespace NewHorizons.Builder.Atmosphere
 {
     public static class FogBuilder
@@ -26,7 +26,9 @@ namespace NewHorizons.Builder.Atmosphere
 
         internal static void InitPrefabs()
         {
-            if (_ramp == null) _ramp = ImageUtilities.GetTexture(Main.Instance, "Assets/textures/FogColorRamp.png");
+            // Checking null here it was getting destroyed and wouldnt reload and never worked outside of the first loop
+            // GetTexture caches itself anyway so it doesn't matter that this gets called multiple times
+             _ramp = ImageUtilities.GetTexture(Main.Instance, "Assets/textures/FogColorRamp.png");
 
             if (_isInit) return;
 
@@ -73,6 +75,7 @@ namespace NewHorizons.Builder.Atmosphere
                 atmo.fogRampPath != null ? ImageUtilities.GetTexture(mod, atmo.fogRampPath) :
                 atmo.fogTint != null ? ImageUtilities.TintImage(_ramp, atmo.fogTint.ToColor()) :
                 _ramp;
+
             PFC.fogColorRampTexture = colorRampTexture;
             PFC.fogColorRampIntensity = 1f;
             if (atmo.fogTint != null)

--- a/NewHorizons/Components/Props/ConditionalObjectActivation.cs
+++ b/NewHorizons/Components/Props/ConditionalObjectActivation.cs
@@ -19,6 +19,7 @@ namespace NewHorizons.Components.Props
         {
             var conditionalObjectActivationGO = new GameObject($"{go.name}_{condition}");
             var component = conditionalObjectActivationGO.AddComponent<ConditionalObjectActivation>();
+            component.transform.parent = go.transform.parent;
             component.GameObject = go;
             component.DialogueCondition = condition;
             component.CloseEyes = closeEyes;

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -518,8 +518,10 @@ namespace NewHorizons
 
                     // We are in a custom system on the first loop -> The time loop isn't active, that's not very good
                     // TimeLoop uses the launch codes condition to know if the loop is active or not
+                    // We also skip them to loop 2, else if they enter a credits volume in this loop they get reset
                     if (CurrentStarSystem != "SolarSystem" && PlayerData.LoadLoopCount() == 1)
                     {
+                        PlayerData.SaveLoopCount(2);
                         PlayerData.SetPersistentCondition("LAUNCH_CODES_GIVEN", true);
                     }
                 }

--- a/NewHorizons/Patches/DialoguePatches/RemoteDialogueTriggerPatches.cs
+++ b/NewHorizons/Patches/DialoguePatches/RemoteDialogueTriggerPatches.cs
@@ -1,4 +1,6 @@
 using HarmonyLib;
+using System.Collections;
+using UnityEngine.InputSystem;
 
 namespace NewHorizons.Patches.DialoguePatches
 {
@@ -6,6 +8,29 @@ namespace NewHorizons.Patches.DialoguePatches
     public static class RemoteDialogueTriggerPatches
     {
         private static bool _wasLastDialogueInactive = false;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(RemoteDialogueTrigger.Awake))]
+        public static void RemoteDialogueTrigger_Awake(RemoteDialogueTrigger __instance)
+        {
+            // Wait for player to be up and moving before allowing them to trigger remote dialogue
+            // Stops you getting locked into dialogue while waking up
+            if (OWInput.GetInputMode() != InputMode.Character)
+            {
+                __instance._collider.enabled = false;
+                __instance.StartCoroutine(AwakeCoroutine(__instance));
+            }
+        }
+
+        private static IEnumerator AwakeCoroutine(RemoteDialogueTrigger instance)
+        {
+            while (OWInput.GetInputMode() != InputMode.Character)
+            {
+                yield return null;
+            }
+
+            instance._collider.enabled = true;
+        }
 
         /// <summary>
         /// Should fix a bug where disabled a CharacterDialogueTree makes its related RemoteDialogueTriggers softlock your game

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.19.4",
+  "version": "1.19.5",
   "owmlVersion": "2.10.3",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "Raicuparta.QuantumSpaceBuddies", "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Improvements
- Conditional object activation GameObject will now be a sibling of the object it acts on. Makes it easier to copy details.
- When starting a new expedition in another solar system, you will skip to loop 2. This means that quitting the game or entering a game over scene will still give you the "Resume Expedition" option on the main menu and not erase your progress.

## Bug fixes
- Fixed fog ramp being null sometimes.
- Fixed getting locked into the "ship warp drive activated" dialogue when spawning inside the ship.
