### PR TITLE
Position and rotation offsets for custom item holding and socketing

### DIFF
--- a/NewHorizons/Builder/Props/ItemBuilder.cs
+++ b/NewHorizons/Builder/Props/ItemBuilder.cs
@@ -51,6 +51,10 @@ namespace NewHorizons.Builder.Props
             item.DisplayName = itemName;
             item.ItemType = itemType;
             item.Droppable = info.droppable;
+            item.HoldOffset = info.holdOffset ?? Vector3.zero;
+            item.HoldRotation = info.holdRotation ?? Vector3.zero;
+            item.SocketOffset = info.socketOffset ?? Vector3.zero;
+            item.SocketRotation = info.socketRotation ?? Vector3.zero;
             if (!string.IsNullOrEmpty(info.pickupAudio))
             {
                 item.PickupAudio = AudioTypeHandler.GetAudioType(info.pickupAudio, mod);

--- a/NewHorizons/Components/Props/NHItem.cs
+++ b/NewHorizons/Components/Props/NHItem.cs
@@ -19,6 +19,10 @@ namespace NewHorizons.Components.Props
         public AudioType DropAudio;
         public AudioType SocketAudio;
         public AudioType UnsocketAudio;
+        public Vector3 HoldOffset;
+        public Vector3 HoldRotation;
+        public Vector3 SocketOffset;
+        public Vector3 SocketRotation;
         public string PickupCondition;
         public bool ClearPickupConditionOnDrop;
         public string PickupFact;
@@ -42,6 +46,8 @@ namespace NewHorizons.Components.Props
         public override void PickUpItem(Transform holdTranform)
         {
             base.PickUpItem(holdTranform);
+            transform.localPosition = HoldOffset;
+            transform.localEulerAngles = HoldRotation;
             TriggerPickupConditions();
             PlayCustomSound(PickupAudio);
         }
@@ -56,6 +62,8 @@ namespace NewHorizons.Components.Props
         public override void SocketItem(Transform socketTransform, Sector sector)
         {
             base.SocketItem(socketTransform, sector);
+            transform.localPosition = SocketOffset;
+            transform.localEulerAngles = SocketRotation;
             TriggerDropConditions();
             PlayCustomSound(SocketAudio);
         }

--- a/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
+++ b/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
@@ -44,6 +44,22 @@ namespace NewHorizons.External.Modules.Props.Item
         /// </summary>
         public MVector3 dropNormal;
         /// <summary>
+        /// A relative offset to apply to the item's position when holding it. The initial position varies for vanilla item types.
+        /// </summary>
+        public MVector3 holdOffset;
+        /// <summary>
+        /// A relative offset to apply to the item's rotation when holding it.
+        /// </summary>
+        public MVector3 holdRotation;
+        /// <summary>
+        /// A relative offset to apply to the item's position when placing it into a socket.
+        /// </summary>
+        public MVector3 socketOffset;
+        /// <summary>
+        /// A relative offset to apply to the item's rotation when placing it into a socket.
+        /// </summary>
+        public MVector3 socketRotation;
+        /// <summary>
         /// The audio to play when this item is picked up. Only applies to custom/non-vanilla item types.
         /// Can be a path to a .wav/.ogg/.mp3 file, or taken from the AudioClip list.
         /// </summary>

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1429,6 +1429,22 @@
           "description": "The direction the item will be oriented when dropping it on the ground. Defaults to up (0, 1, 0).",
           "$ref": "#/definitions/MVector3"
         },
+        "holdOffset": {
+          "description": "A relative offset to apply to the item's position when holding it. The initial position varies for vanilla item types.",
+          "$ref": "#/definitions/MVector3"
+        },
+        "holdRotation": {
+          "description": "A relative offset to apply to the item's rotation when holding it.",
+          "$ref": "#/definitions/MVector3"
+        },
+        "socketOffset": {
+          "description": "A relative offset to apply to the item's position when placing it into a socket.",
+          "$ref": "#/definitions/MVector3"
+        },
+        "socketRotation": {
+          "description": "A relative offset to apply to the item's rotation when placing it into a socket.",
+          "$ref": "#/definitions/MVector3"
+        },
         "pickupAudio": {
           "type": "string",
           "description": "The audio to play when this item is picked up. Only applies to custom/non-vanilla item types.\nCan be a path to a .wav/.ogg/.mp3 file, or taken from the AudioClip list."


### PR DESCRIPTION
## Minor features
- Added `holdOffset`, `holdRotation`, `socketOffset`, and `socketRotation` to control the positioning of custom items when held or socketed (implements #821).