### PR TITLE
ReuseDialogueOptionsListFrom

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -156,7 +156,7 @@ namespace NewHorizons.Builder.Props
                         // If they're adding dialogue we have to manually register the xml text
                         if (isFromAssetBundle && component is CharacterDialogueTree dialogue)
                         {
-                            DialogueBuilder.AddTranslation(dialogue._xmlCharacterDialogueAsset.text, null);
+                            DialogueBuilder.HandleUnityCreatedDialogue(dialogue);
                         }
 
                         FixComponent(component, go, detail.ignoreSun);

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -106,7 +106,11 @@ namespace NewHorizons.Builder.Props
                     // We just have to merge the dialogue options
                     var dialogueOptions = newDialogueNode.GetChildNode("DialogueOptionsList").GetChildNodes("DialogueOption");
                     var existingDialogueOptionsList = existingNode.GetChildNode("DialogueOptionsList");
-                    var firstNode = existingDialogueOptionsList.ChildNodes[0];
+                    if (existingDialogueOptionsList == null)
+                    {
+                        existingDialogueOptionsList = existingDialogueDoc.CreateElement("DialogueOptionsList");
+                        existingNode.AppendChild(existingDialogueOptionsList);
+                    }
                     foreach (XmlNode node in dialogueOptions)
                     {
                         var importedNode = existingDialogueOptionsList.OwnerDocument.ImportNode(node, true);

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -130,8 +130,6 @@ namespace NewHorizons.Builder.Props
             var characterName = existingDialogueTree.SelectSingleNode("NameField").InnerText;
             AddTranslation(additionalDialogueDoc.GetChildNode("DialogueTree"), characterName);
 
-            DoDialogueOptionsListReplacement(existingDialogueTree);
-
             var newTextAsset = new TextAsset(existingDialogueDoc.OuterXml)
             {
                 name = existingDialogue._xmlCharacterDialogueAsset.name
@@ -139,7 +137,30 @@ namespace NewHorizons.Builder.Props
 
             existingDialogue.SetTextXml(newTextAsset);
 
+            FixDialogueNextFrame(existingDialogue);
+
             return existingDialogue;
+        }
+
+        private static void FixDialogueNextFrame(CharacterDialogueTree characterDialogueTree)
+        {
+            Delay.FireOnNextUpdate(() =>
+            {
+                var rawText = characterDialogueTree._xmlCharacterDialogueAsset.text;
+
+                var doc = new XmlDocument();
+                doc.LoadXml(rawText);
+                var dialogueTree = doc.DocumentElement.SelectSingleNode("//DialogueTree");
+
+                DoDialogueOptionsListReplacement(dialogueTree);
+
+                var newTextAsset = new TextAsset(doc.OuterXml)
+                {
+                    name = characterDialogueTree._xmlCharacterDialogueAsset.name
+                };
+
+                characterDialogueTree.SetTextXml(newTextAsset);
+            });
         }
 
         /// <summary>
@@ -253,7 +274,7 @@ namespace NewHorizons.Builder.Props
             dialogueDoc.LoadXml(xml);
             var xmlNode = dialogueDoc.SelectSingleNode("DialogueTree");
             AddTranslation(xmlNode);
-            DoDialogueOptionsListReplacement(xmlNode);
+
             xml = xmlNode.OuterXml;
 
             var text = new TextAsset(xml)
@@ -281,6 +302,8 @@ namespace NewHorizons.Builder.Props
             }
 
             conversationZone.SetActive(true);
+
+            FixDialogueNextFrame(dialogueTree);
 
             return dialogueTree;
         }
@@ -499,12 +522,13 @@ namespace NewHorizons.Builder.Props
             dialogueDoc.LoadXml(text);
             var xmlNode = dialogueDoc.SelectSingleNode("DialogueTree");
             AddTranslation(xmlNode, null);
-            DoDialogueOptionsListReplacement(xmlNode);
             var newTextAsset = new TextAsset(dialogueDoc.OuterXml)
             {
                 name = dialogue._xmlCharacterDialogueAsset.name
             };
             dialogue.SetTextXml(newTextAsset);
+
+            FixDialogueNextFrame(dialogue);
         }
     }
 }

--- a/NewHorizons/Components/Fixers/PlayerShipAtmosphereDetectorFix.cs
+++ b/NewHorizons/Components/Fixers/PlayerShipAtmosphereDetectorFix.cs
@@ -14,7 +14,11 @@ internal class PlayerShipAtmosphereDetectorFix : MonoBehaviour
     public void Start()
     {
         _fluidDetector = Locator.GetPlayerCameraDetector().GetComponent<PlayerCameraFluidDetector>();
-        _shipAtmosphereVolume = Locator.GetShipBody().transform.Find("Volumes/ShipAtmosphereVolume").GetComponent<SimpleFluidVolume>();
+        _shipAtmosphereVolume = Locator.GetShipBody()?.transform?.Find("Volumes/ShipAtmosphereVolume")?.GetComponent<SimpleFluidVolume>();
+        if (_shipAtmosphereVolume == null)
+        {
+            Destroy(this);
+        }
     }
 
     public void Update()

--- a/NewHorizons/Handlers/TranslationHandler.cs
+++ b/NewHorizons/Handlers/TranslationHandler.cs
@@ -173,6 +173,26 @@ namespace NewHorizons.Handlers
             TextTranslation.Get().m_table.theTable[key] = value;
         }
 
+        /// <summary>
+        /// Two dialogue nodes might share indentical text but they will have different prefixes. Still, we want to reuse that old text.
+        /// </summary>
+        /// <param name="rawText"></param>
+        /// <param name="oldPrefixes"></param>
+        /// <param name="newPrefixes"></param>
+        public static void ReuseDialogueTranslation(string rawText, string[] oldPrefixes, string[] newPrefixes)
+        {
+            var key = string.Join(string.Empty, newPrefixes) + rawText;
+            var existingKey = string.Join(string.Empty, oldPrefixes) + rawText;
+            if (TextTranslation.Get().m_table.theTable.TryGetValue(existingKey, out var existingTranslation))
+            {
+                TextTranslation.Get().m_table.theTable[key] = existingTranslation;
+            }
+            else
+            {
+                NHLogger.LogWarning($"Couldn't find translation key {existingKey}");
+            }
+        }
+
         public static void AddShipLog(string rawText, params string[] rawPreText)
         {
             var key = string.Join(string.Empty, rawPreText) + rawText;

--- a/NewHorizons/Utility/NewHorizonExtensions.cs
+++ b/NewHorizons/Utility/NewHorizonExtensions.cs
@@ -348,7 +348,7 @@ namespace NewHorizons.Utility
 
         public static XmlNode GetChildNode(this XmlNode parentNode, string tagName)
         {
-            return parentNode.ChildNodes.Cast<XmlNode>().First(node => node.LocalName == tagName);
+            return parentNode.ChildNodes.Cast<XmlNode>().FirstOrDefault(node => node.LocalName == tagName);
         }
 
         public static string TruncateWhitespaceAndToLower(this string text)

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "owmlVersion": "2.10.3",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Minor features
- To avoid having to copy paste a repeated `DialogueOptionsList`, you can instead put `ReuseDialogueOptionsListFrom` and reference another `DialogueNode` whose options you want to repeat. Implements #854

