### PR TITLE
Allow spawned rafts to change water fluids and prevent NRE if one isn…

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -417,6 +417,11 @@ namespace NewHorizons.Builder.Props
             {
                 component.gameObject.AddComponent<AnglerAnimFixer>();
             }
+            // Add custom logic to NH-spawned rafts to handle fluid changes
+            else if (component is RaftController raft)
+            {
+                component.gameObject.AddComponent<NHRaftController>();
+            }
         }
 
         /// <summary>

--- a/NewHorizons/Builder/Props/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/RaftBuilder.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Components.Props;
 using NewHorizons.External.Modules.Props.EchoesOfTheEye;
 using NewHorizons.Handlers;
 using NewHorizons.Utility;
@@ -72,6 +73,8 @@ namespace NewHorizons.Builder.Props
                 lightSensor._sector = sector;
                 sector.OnSectorOccupantsUpdated += lightSensor.OnSectorOccupantsUpdated;
             }
+
+            var nhRaftController = raftObject.AddComponent<NHRaftController>();
 
             var achievementObject = new GameObject("AchievementVolume");
             achievementObject.transform.SetParent(raftObject.transform, false);

--- a/NewHorizons/Components/Props/NHRaftController.cs
+++ b/NewHorizons/Components/Props/NHRaftController.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace NewHorizons.Components.Props
+{
+    public class NHRaftController : MonoBehaviour
+    {
+        RaftController raft;
+
+        public void OnEnable()
+        {
+            raft = GetComponent<RaftController>();
+            raft._fluidDetector.OnEnterFluid += OnEnterFluid;
+        }
+
+        public void OnDisable()
+        {
+            raft._fluidDetector.OnEnterFluid -= OnEnterFluid;
+        }
+
+        private void OnEnterFluid(FluidVolume volume)
+        {
+            if (volume.GetFluidType() == FluidVolume.Type.WATER)
+            {
+                raft._fluidDetector._alignmentFluid = volume;
+            }
+        }
+    }
+}

--- a/NewHorizons/Patches/EchoesOfTheEyePatches/RaftControllerPatches.cs
+++ b/NewHorizons/Patches/EchoesOfTheEyePatches/RaftControllerPatches.cs
@@ -63,7 +63,8 @@ namespace NewHorizons.Patches.EchoesOfTheEyePatches
             if (__instance._playerInEffectsRange)
             {
                 // All this to change what fluidVolume we use on this line
-                float num = __instance._fluidDetector.InFluidType(FluidVolume.Type.WATER) ? __instance._fluidDetector._alignmentFluid.GetFractionSubmerged(__instance._fluidDetector) : 0f;
+                FluidVolume volume = __instance._fluidDetector._alignmentFluid;
+                float num = __instance._fluidDetector.InFluidType(FluidVolume.Type.WATER) && volume != null ? volume.GetFractionSubmerged(__instance._fluidDetector) : 0f;
                 bool allowMovement = num > 0.25f && num < 1f;
                 __instance._effectsController.UpdateMovementAudio(allowMovement, __instance._lightSensors);
                 __instance._effectsController.UpdateGroundedAudio(__instance._fluidDetector);


### PR DESCRIPTION
## Bug fixes
- Rafts spawned with New Horizons update their "alignment volume" when they enter water volumes, allowing them to move between different bodies of water or be spawned on planets without oceans. Fixes #846 .