### PR TITLE
Fix and update xsd schemas

### DIFF
--- a/NewHorizons/Schemas/dialogue_schema.xsd
+++ b/NewHorizons/Schemas/dialogue_schema.xsd
@@ -59,24 +59,10 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="DialogueOptionsList" type="DialogueOptionsList" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        A list of options to show to the player once the character is done talking
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="RevealFacts" type="RevealFacts" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Facts to reveal when the player goes through this dialogue node
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="SetCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>
-                        Set a new condition that will only last for the current loop
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -85,6 +71,13 @@
                     <xs:documentation>
                         Set a new persistent condition that will last indefinitely in the current save, unless cancelled
                         or deleted
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="SetCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Set a new condition that will only last for the current loop
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -107,6 +100,13 @@
                     <xs:documentation>
                         The name of the `DialogueNode` to go to after this node. Mutually exclusive with
                         `DialogueOptionsList` here
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="DialogueOptionsList" type="DialogueOptionsList" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        A list of options to show to the player once the character is done talking
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -162,6 +162,13 @@
     <!-- Dialogue Option Info -->
     <xs:complexType name="DialogueOption">
         <xs:sequence>
+            <xs:element name="RequiredLogCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Require a ship log fact to be known to show this option
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="RequiredPersistentCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
@@ -190,17 +197,17 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RequiredLogCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation>
-                        Require a ship log fact to be known to show this option
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
             <xs:element name="Text" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The text to show for this option
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the `DialogueNode` to go to when this option is selected
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -215,13 +222,6 @@
                 <xs:annotation>
                     <xs:documentation>
                         Cancel a condition when this option is chosen
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation>
-                        The name of the `DialogueNode` to go to when this option is selected
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/NewHorizons/Schemas/dialogue_schema.xsd
+++ b/NewHorizons/Schemas/dialogue_schema.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Dialogue Tree -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <!-- Empty Type -->
@@ -8,7 +8,7 @@
     <xs:element name="DialogueTree">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="NameField" type="xs:string">
+                <xs:element name="NameField" type="xs:string" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             The name of the character, used for the interaction prompt. Set to `SIGN` for the prompt
@@ -16,7 +16,7 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-                <xs:element name="DialogueNode" type="DialogueNode" maxOccurs="unbounded">
+                <xs:element name="DialogueNode" type="DialogueNode" minOccurs="1" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
                             The different nodes of this dialogue tree
@@ -30,7 +30,7 @@
     <!-- Dialogue Node Info -->
     <xs:complexType name="DialogueNode">
         <xs:sequence>
-            <xs:element name="Name" type="xs:string">
+            <xs:element name="Name" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The name of this dialogue node
@@ -45,28 +45,28 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Randomize" type="empty" minOccurs="0">
+            <xs:element name="Randomize" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         When used with multiple Dialogues, the node will choose a random one to show
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Dialogue" type="Dialogue" maxOccurs="unbounded">
+            <xs:element name="Dialogue" type="Dialogue" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
                         The dialogue to show to the player
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="DialogueOptionsList" type="DialogueOptionsList" minOccurs="0">
+            <xs:element name="DialogueOptionsList" type="DialogueOptionsList" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         A list of options to show to the player once the character is done talking
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RevealFacts" type="RevealFacts" minOccurs="0">
+            <xs:element name="RevealFacts" type="RevealFacts" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Facts to reveal when the player goes through this dialogue node
@@ -80,11 +80,18 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="SetPersistentCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="SetPersistentCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Set a new persistent condition that will last indefinitely in the current save, unless cancelled
                         or deleted
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="DisablePersistentCondition" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Disable a set persistent condition from the current save
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -95,7 +102,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0">
+            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The name of the `DialogueNode` to go to after this node. Mutually exclusive with
@@ -109,7 +116,7 @@
     <!-- Dialogue Info -->
     <xs:complexType name="Dialogue">
         <xs:sequence>
-            <xs:element name="Page" type="xs:string" maxOccurs="unbounded">
+            <xs:element name="Page" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
                         A page of dialogue to show to the player
@@ -122,7 +129,7 @@
     <!-- Reveal Facts Info -->
     <xs:complexType name="RevealFacts">
         <xs:sequence>
-            <xs:element name="FactID" type="xs:string" maxOccurs="unbounded">
+            <xs:element name="FactID" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
                         The ID of a fact to reveal
@@ -135,10 +142,17 @@
     <!-- Dialogue Options List Info -->
     <xs:complexType name="DialogueOptionsList">
         <xs:sequence>
-            <xs:element name="DialogueOption" type="DialogueOption" maxOccurs="unbounded">
+            <xs:element name="DialogueOption" type="DialogueOption" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation>
                         Options the player can select from
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ReuseDialogueOptionsListFrom" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of another DialogueNode whose options you want to repeat to avoid having to copy paste
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -162,14 +176,14 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RequiredCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="RequiredCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Require a (single-loop) condition to be met to show this option
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="CancelledCondition" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="CancelledCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Hide this option if a (single-loop) condition has been met
@@ -183,28 +197,28 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Text" type="xs:string">
+            <xs:element name="Text" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The text to show for this option
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="ConditionToSet" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="ConditionToSet" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Set a condition when this option is chosen
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="ConditionToCancel" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="ConditionToCancel" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Cancel a condition when this option is chosen
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0">
+            <xs:element name="DialogueTarget" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The name of the `DialogueNode` to go to when this option is selected

--- a/NewHorizons/Schemas/shiplog_schema.xsd
+++ b/NewHorizons/Schemas/shiplog_schema.xsd
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Ship Log Entries -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <!-- Astro Object Entry Info -->
     <xs:element name="AstroObjectEntry">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="ID" type="xs:string">
+                <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="1">
                     <xs:annotation>
                         <xs:documentation>
                             ID of the planet these entries are for
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-                <xs:element name="Entry" type="Entry" maxOccurs="unbounded">
+                <xs:element name="Entry" type="Entry" minOccurs="0" maxOccurs="unbounded">
                     <xs:annotation>
                         <xs:documentation>
                             A set of entries that belong to this planet
@@ -29,49 +29,56 @@
     <!-- Entry Info -->
     <xs:complexType name="Entry">
         <xs:sequence>
-            <xs:element name="ID" type="xs:string">
+            <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The ID of this entry
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Name" type="xs:string">
+            <xs:element name="Name" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Name of this entry
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Curiosity" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Curiosity" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The curiosity this entry belongs to
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="IsCuriosity" type="empty" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="IsCuriosity" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Whether this entry is a curiosity
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0">
+            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Whether to hide the "More To Explore" text on this entry
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="IgnoreMoreToExploreCondition" type="xs:string" minOccurs="0">
+            <xs:element name="ParentIgnoreNotRevealed" type="empty" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        When the parent of this entry is determining whether its "More To Explore" text should appear, this child entry will be ignored.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="IgnoreMoreToExploreCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Ignore more to explore if a persistent condition is `true`
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="AltPhotoCondition" type="xs:string" minOccurs="0">
+            <xs:element name="AltPhotoCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         If this fact is revealed, show the Alt picture
@@ -105,35 +112,35 @@
     <!-- Rumor Fact Info -->
     <xs:complexType name="RumorFact">
         <xs:sequence>
-            <xs:element name="ID" type="xs:string">
+            <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The ID of this rumor fact
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="SourceID" type="xs:string" minOccurs="0">
+            <xs:element name="SourceID" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The source of this rumor, this draws a line in detective mode
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RumorName" type="xs:string" minOccurs="0">
+            <xs:element name="RumorName" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Displays on the card in detective mode if no ExploreFacts have been revealed on the parent entry
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RumorNamePriority" type="xs:int" minOccurs="0">
+            <xs:element name="RumorNamePriority" type="xs:int" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Priority over other RumorFacts to appear as the entry card's title
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0">
+            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Whether to hide the "More to explore" on this rumor fact
@@ -147,14 +154,14 @@
     <!-- Explore Fact Info -->
     <xs:complexType name="ExploreFact">
         <xs:sequence>
-            <xs:element name="ID" type="xs:string">
+            <xs:element name="ID" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The ID of this explore fact
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0">
+            <xs:element name="IgnoreMoreToExplore" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Whether to hide the "More to explore" text for this fact
@@ -168,14 +175,14 @@
     <!-- Text Data Group -->
     <xs:group name="TextData">
         <xs:sequence>
-            <xs:element name="Text" type="xs:string">
+            <xs:element name="Text" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         The text content for this fact
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="AltText" minOccurs="0">
+            <xs:element name="AltText" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
                         Display alt-text given a certain fact is revealed
@@ -183,14 +190,14 @@
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element name="Text" type="xs:string">
+                        <xs:element name="Text" type="xs:string" minOccurs="1" maxOccurs="1">
                             <xs:annotation>
                                 <xs:documentation>
                                     The text to display if the condition is met
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:element>
-                        <xs:element name="Condition" type="xs:string">
+                        <xs:element name="Condition" type="xs:string" minOccurs="1" maxOccurs="unbounded">
                             <xs:annotation>
                                 <xs:documentation>
                                     The condition that needs to be fulfilled to have the alt text be displayed

--- a/NewHorizons/Schemas/text_schema.xsd
+++ b/NewHorizons/Schemas/text_schema.xsd
@@ -27,27 +27,27 @@
     <!-- Text Block Info -->
     <xs:complexType name="TextBlock">
         <xs:sequence>
-            <xs:element name="ID" type="xs:positiveInteger">
+            <xs:element name="ID" type="xs:positiveInteger" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> The id of this text block </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="ParentID" type="xs:positiveInteger" minOccurs="0">
+            <xs:element name="ParentID" type="xs:positiveInteger" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> The id of the parent text block </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="LocationA" type="empty" minOccurs="0">
+            <xs:element name="LocationA" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="LocationB" type="empty" minOccurs="0">
+            <xs:element name="LocationB" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="Text" type="xs:string">
+            <xs:element name="Text" type="xs:string" minOccurs="1" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> The text to show for this option </xs:documentation>
                 </xs:annotation>
@@ -58,17 +58,17 @@
     <!-- Ship Log Conditions Info -->
     <xs:complexType name="ShipLogConditions">
         <xs:sequence>
-            <xs:element name="LocationA" type="empty" minOccurs="0">
+            <xs:element name="LocationA" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="LocationB" type="empty" minOccurs="0">
+            <xs:element name="LocationB" type="empty" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation> </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="RevealFact" type="RevealFact" minOccurs="0">
+            <xs:element name="RevealFact" type="RevealFact" minOccurs="0" maxOccurs="unbounded">
                 <xs:annotation>
                     <xs:documentation> Facts to reveal when the player goes through this dialogue
                         node </xs:documentation>


### PR DESCRIPTION
## Improvements

- Added ReuseDialogueOptionsListFrom, DisablePersistentCondition, and ParentIgnoreNotRevealed to their respective schemas
- Specify (and also correct some) minOccurs & maxOccurs on EVERYTHING (this one is for you visual studio)

- Rearranged things to better match the xmls from vanilla