### PR TITLE
Scatter parenting and fixes for tidally locked bodies

### DIFF
--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -47,17 +47,6 @@ namespace NewHorizons.Builder.Props
                     }
                 }
             }
-            if (config.Props.scatter != null)
-            {
-                try
-                {
-                    ScatterBuilder.Make(go, sector, config, mod);
-                }
-                catch (Exception ex)
-                {
-                    NHLogger.LogError($"Couldn't make planet scatter for [{go.name}]:\n{ex}");
-                }
-            }
             if (config.Props.details != null)
             {
                 foreach (var detail in config.Props.details)
@@ -70,6 +59,17 @@ namespace NewHorizons.Builder.Props
                     {
                         NHLogger.LogError($"Couldn't make planet detail [{detail.path}] for [{go.name}]:\n{ex}");
                     }
+                }
+            }
+            if (config.Props.scatter != null)
+            {
+                try
+                {
+                    ScatterBuilder.Make(go, sector, config, mod);
+                }
+                catch (Exception ex)
+                {
+                    NHLogger.LogError($"Couldn't make planet scatter for [{go.name}]:\n{ex}");
                 }
             }
             if (config.Props.geysers != null)

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -139,6 +139,7 @@ namespace NewHorizons.Builder.Props
                     }
 
                     var prop = scatterPrefab.InstantiateInactive();
+                    // Have to use SetParent method to work with tidally locked bodies #872
                     prop.transform.SetParent(parent, false);
                     prop.transform.localPosition = point * height;
                     var up = (prop.transform.position - go.transform.position).normalized;

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -140,7 +140,7 @@ namespace NewHorizons.Builder.Props
 
                     var prop = scatterPrefab.InstantiateInactive();
                     prop.transform.SetParent(parent, false);
-                    prop.transform.position = go.transform.TransformPoint(point * height);
+                    prop.transform.localPosition = point * height;
                     var up = (prop.transform.position - go.transform.position).normalized;
                     prop.transform.rotation = Quaternion.FromToRotation(Vector3.up, up);
 

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -3,6 +3,7 @@ using NewHorizons.External.Modules.Props;
 using NewHorizons.Utility;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.Geometry;
+using NewHorizons.Utility.OWML;
 using OWML.Common;
 using System;
 using System.Collections.Generic;
@@ -120,10 +121,27 @@ namespace NewHorizons.Builder.Props
                         }
                     }
 
+
+                    var parent = sector?.transform ?? go.transform;
+
+                    if (go != null && !string.IsNullOrEmpty(propInfo.parentPath))
+                    {
+                        var newParent = go.transform.Find(propInfo.parentPath);
+                        if (newParent != null)
+                        {
+                            parent = newParent;
+                            sector = newParent.GetComponentInParent<Sector>();
+                        }
+                        else
+                        {
+                            NHLogger.LogError($"Cannot find parent object at path: {go.name}/{propInfo.parentPath}");
+                        }
+                    }
+
                     var prop = scatterPrefab.InstantiateInactive();
-                    prop.transform.SetParent(sector?.transform ?? go.transform);
-                    prop.transform.localPosition = go.transform.TransformPoint(point * height);
-                    var up = go.transform.InverseTransformPoint(prop.transform.position).normalized;
+                    prop.transform.SetParent(parent, false);
+                    prop.transform.position = go.transform.TransformPoint(point * height);
+                    var up = (prop.transform.position - go.transform.position).normalized;
                     prop.transform.rotation = Quaternion.FromToRotation(Vector3.up, up);
 
                     if (propInfo.offset != null) prop.transform.localPosition += prop.transform.TransformVector(propInfo.offset);

--- a/NewHorizons/External/Modules/Props/ScatterInfo.cs
+++ b/NewHorizons/External/Modules/Props/ScatterInfo.cs
@@ -68,7 +68,7 @@ namespace NewHorizons.External.Modules.Props
         public bool keepLoaded;
 
         /// <summary>
-        /// The relative path from the planet to the parent of this object. Optional (will default to the root sector).
+        /// The relative path from the planet to the parent of this object. Optional (will default to the root sector). This parent should be at the position where you'd like to scatter (which would usually be zero).
         /// </summary>
         public string parentPath;
     }

--- a/NewHorizons/External/Modules/Props/ScatterInfo.cs
+++ b/NewHorizons/External/Modules/Props/ScatterInfo.cs
@@ -66,5 +66,10 @@ namespace NewHorizons.External.Modules.Props
         /// Should this detail stay loaded even if you're outside the sector (good for very large props)
         /// </summary>
         public bool keepLoaded;
+
+        /// <summary>
+        /// The relative path from the planet to the parent of this object. Optional (will default to the root sector).
+        /// </summary>
+        public string parentPath;
     }
 }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2046,6 +2046,10 @@
         "keepLoaded": {
           "type": "boolean",
           "description": "Should this detail stay loaded even if you're outside the sector (good for very large props)"
+        },
+        "parentPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector). This parent should be at the position where you'd like to scatter (which would usually be zero)."
         }
       }
     },


### PR DESCRIPTION
## Minor features

- Added `parentPath` to scatter. This parent should be at the position where you'd like to scatter (which would usually be zero).

## Bug fixes

- Fix scatter not working properly on tidally locked bodies