### PR TITLE
Check InConversation to avoid unnecessary EndConversation calls

### DIFF
--- a/NewHorizons/Patches/DialoguePatches/CharacterDialogueTreePatches.cs
+++ b/NewHorizons/Patches/DialoguePatches/CharacterDialogueTreePatches.cs
@@ -24,7 +24,10 @@ public static class CharacterDialogueTreePatches
 
     private static void OnAttachPlayerToPoint(this CharacterDialogueTree characterDialogueTree, OWRigidbody rigidbody)
     {
-        characterDialogueTree.EndConversation();
+        if (characterDialogueTree.InConversation())
+        {
+            characterDialogueTree.EndConversation();
+        }
     }
 
     [HarmonyPostfix]


### PR DESCRIPTION
## Improvements

- fix #859: CharacterDialogueTree.InConversation is now checked in our attachment patch to avoid unnecessary EndConversation calls.