### PR TITLE
Add different slide reel prefabs

### DIFF
--- a/NewHorizons/Assets/newhorizons_private.manifest
+++ b/NewHorizons/Assets/newhorizons_private.manifest
@@ -1,12 +1,12 @@
 ManifestFileVersion: 0
-CRC: 3537427957
+CRC: 423323461
 Hashes:
   AssetFileHash:
     serializedVersion: 2
-    Hash: c4d8f41970054074bb375ac5cbe82855
+    Hash: 4199cf66477e2054e4ac61871d811161
   TypeTreeHash:
     serializedVersion: 2
-    Hash: de71b9c55befb829b1640ea21774b932
+    Hash: 83784250589f972ee0b86ea39a5a5305
 HashAppended: 0
 ClassTypes:
 - Class: 1
@@ -16,6 +16,8 @@ ClassTypes:
 - Class: 21
   Script: {instanceID: 0}
 - Class: 23
+  Script: {instanceID: 0}
+- Class: 28
   Script: {instanceID: 0}
 - Class: 33
   Script: {instanceID: 0}
@@ -76,6 +78,8 @@ ClassTypes:
 - Class: 114
   Script: {fileID: 11500000, guid: 327eb94566c9e284dae5d7b1cfe11ccd, type: 3}
 - Class: 114
+  Script: {fileID: 11500000, guid: 8d56b3759dd12424c8425ed62fc02796, type: 3}
+- Class: 114
   Script: {fileID: 11500000, guid: c317f6a5634f15f4c80f89e306616924, type: 3}
 - Class: 114
   Script: {fileID: 11500000, guid: 13ab18a571ddf1b4f8dc92e3fa31b22e, type: 3}
@@ -98,9 +102,13 @@ ClassTypes:
 - Class: 114
   Script: {fileID: 11500000, guid: 64247dd7b0c5ac640a6d9ae5360a0f5a, type: 3}
 - Class: 114
+  Script: {fileID: 11500000, guid: f645b92850d716a4488617b651223700, type: 3}
+- Class: 114
   Script: {fileID: 11500000, guid: 8ef66a28deb09ab4aaba30bb60b9f19a, type: 3}
 - Class: 114
   Script: {fileID: 11500000, guid: 0863077874402f14dba0ca4ae81752dd, type: 3}
+- Class: 114
+  Script: {fileID: 11500000, guid: bf998978a8a701b4eb09fcd94048f916, type: 3}
 - Class: 114
   Script: {fileID: 11500000, guid: a9da74c8b134add4ba1d884336a5e075, type: 3}
 - Class: 114
@@ -171,7 +179,24 @@ ClassTypes:
   Script: {instanceID: 0}
 SerializeReferenceClassIdentifiers: []
 Assets:
+- Assets/SlideReels/Prefab_DW_Reel_Whole.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Rusted_7.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Destroyed_6.prefab
+- Assets/SlideReels/Effects_IP_SIM_SlideReel.prefab
+- Assets/SlideReels/Prefab_DW_Reel_7.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Rusted_6.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Rusted_8.prefab
+- Assets/SlideReels/Prefab_DW_Reel_6.prefab
+- Assets/SlideReels/Prefab_IP_Reel_8.prefab
+- Assets/SlideReels/Prefab_IP_Reel_6.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Destroyed_7.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Destroyed_Whole.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Destroyed_8.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Whole.prefab
+- Assets/SlideReels/Prefab_IP_Reel_Rusted_Whole.prefab
 - Assets/BrambleCollision.prefab
+- Assets/SlideReels/Prefab_DW_Reel_8.prefab
 - Assets/Vessel_Body.prefab
 - Assets/AmbientLight_QM.png
+- Assets/SlideReels/Prefab_IP_Reel_7.prefab
 Dependencies: []

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -419,6 +419,7 @@ namespace NewHorizons.Builder.Props
             {
                 var slide = new Slide();
                 var slideInfo = slides[i];
+                slide._streamingImageID = i; // for SlideRotationModule
 
                 if (string.IsNullOrEmpty(slideInfo.imagePath))
                 {
@@ -492,6 +493,10 @@ namespace NewHorizons.Builder.Props
                     _entryKey = slideInfo.reveal
                 };
                 modules.Add(shipLogEntry);
+            }
+            if (slideInfo.rotate)
+            {
+                modules.Add(new SlideRotationModule());
             }
 
             Slide.WriteModules(modules, ref slide._modulesList, ref slide._modulesData, ref slide.lengths);

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -10,12 +10,29 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using UnityEngine;
+using static NewHorizons.Main;
 
 namespace NewHorizons.Builder.Props
 {
     public static class ProjectionBuilder
     {
-        private static GameObject _slideReelPrefab;
+        public static GameObject SlideReelWholePrefab { get; private set; }
+        public static GameObject SlideReelWholePristinePrefab { get; private set; }
+        public static GameObject SlideReelWholeRustedPrefab { get; private set; }
+        public static GameObject SlideReelWholeDestroyedPrefab { get; private set; }
+        public static GameObject SlideReel8Prefab { get; private set; }
+        public static GameObject SlideReel8PristinePrefab { get; private set; }
+        public static GameObject SlideReel8RustedPrefab { get; private set; }
+        public static GameObject SlideReel8DestroyedPrefab { get; private set; }
+        public static GameObject SlideReel7Prefab { get; private set; }
+        public static GameObject SlideReel7PristinePrefab { get; private set; }
+        public static GameObject SlideReel7RustedPrefab { get; private set; }
+        public static GameObject SlideReel7DestroyedPrefab { get; private set; }
+        public static GameObject SlideReel6Prefab { get; private set; }
+        public static GameObject SlideReel6PristinePrefab { get; private set; }
+        public static GameObject SlideReel6RustedPrefab { get; private set; }
+        public static GameObject SlideReel6DestroyedPrefab { get; private set; }
+
         private static GameObject _autoPrefab;
         private static GameObject _visionTorchDetectorPrefab;
         private static GameObject _standingVisionTorchPrefab;
@@ -29,14 +46,22 @@ namespace NewHorizons.Builder.Props
 
             _isInit = true;
 
-            if (_slideReelPrefab == null)
-            {
-                _slideReelPrefab = SearchUtilities.Find("RingWorld_Body/Sector_RingInterior/Sector_Zone1/Sector_SlideBurningRoom_Zone1/Interactables_SlideBurningRoom_Zone1/Prefab_IP_SecretAlcove/RotationPivot/SlideReelSocket/Prefab_IP_Reel_1_LibraryPath")?.gameObject?.InstantiateInactive()?.Rename("Prefab_IP_Reel")?.DontDestroyOnLoad();
-                if (_slideReelPrefab == null)
-                    NHLogger.LogWarning($"Tried to make slide reel prefab but couldn't. Do you have the DLC installed?");
-                else
-                    _slideReelPrefab.AddComponent<DestroyOnDLC>()._destroyOnDLCNotOwned = true;
-            }
+            SlideReelWholePrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Whole");
+            SlideReelWholePristinePrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_DW_Reel_Whole");
+            SlideReelWholeRustedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Rusted_Whole");
+            SlideReelWholeDestroyedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Destroyed_Whole");
+            SlideReel8Prefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_8");
+            SlideReel8PristinePrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_DW_Reel_8");
+            SlideReel8RustedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Rusted_8");
+            SlideReel8DestroyedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Destroyed_8");
+            SlideReel7Prefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_7");
+            SlideReel7PristinePrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_DW_Reel_7");
+            SlideReel7RustedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Rusted_7");
+            SlideReel7DestroyedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Destroyed_7");
+            SlideReel6Prefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_6");
+            SlideReel6PristinePrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_DW_Reel_6");
+            SlideReel6RustedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Rusted_6");
+            SlideReel6DestroyedPrefab = NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_IP_Reel_Destroyed_6");
 
             if (_autoPrefab == null)
             {
@@ -92,9 +117,11 @@ namespace NewHorizons.Builder.Props
         {
             InitPrefabs();
 
-            if (_slideReelPrefab == null) return null;
+            GameObject prefab = GetSlideReelPrefab(info.reelModel, info.reelCondition);
 
-            var slideReelObj = GeneralPropBuilder.MakeFromPrefab(_slideReelPrefab, $"Prefab_IP_Reel_{mod.ModHelper.Manifest.Name}", planetGO, sector, info);
+            if (prefab == null) return null;
+
+            var slideReelObj = GeneralPropBuilder.MakeFromPrefab(prefab, $"Prefab_IP_Reel_{GetSlideReelName(info.reelModel, info.reelCondition)}_{mod.ModHelper.Manifest.Name}", planetGO, sector, info);
 
             var slideReel = slideReelObj.GetComponent<SlideReelItem>();
             slideReel.SetSector(sector);
@@ -124,25 +151,27 @@ namespace NewHorizons.Builder.Props
             int displaySlidesLoaded = 0;
             imageLoader.imageLoadedEvent.AddListener(
                 (Texture2D tex, int index) => 
-                { 
+                {
                     slideCollection.slides[index]._image = ImageUtilities.Invert(tex); 
 
                     // Track the first 15 to put on the slide reel object
                     if (index < textures.Length) 
                     {
                         textures[index] = tex;
-                        if (Interlocked.Increment(ref displaySlidesLoaded) == textures.Length)
+                        if (Interlocked.Increment(ref displaySlidesLoaded) >= textures.Length)
                         {
                             // all textures required to build the reel's textures have been loaded
-                            var slidesBack = slideReelObj.transform.Find("Props_IP_SlideReel_7/Slides_Back").GetComponent<MeshRenderer>();
-                            var slidesFront = slideReelObj.transform.Find("Props_IP_SlideReel_7/Slides_Front").GetComponent<MeshRenderer>();
+                            var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Back").GetComponent<MeshRenderer>();
+                            var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Front").GetComponent<MeshRenderer>();
 
                             // Now put together the textures into a 4x4 thing for the materials
                             var reelTexture = ImageUtilities.MakeReelTexture(textures);
                             slidesBack.material.mainTexture = reelTexture;
                             slidesBack.material.SetTexture(EmissionMap, reelTexture);
+                            slidesBack.material.name = reelTexture.name;
                             slidesFront.material.mainTexture = reelTexture;
                             slidesFront.material.SetTexture(EmissionMap, reelTexture);
+                            slidesFront.material.name = reelTexture.name;
                         }
                     }
                 }
@@ -160,6 +189,82 @@ namespace NewHorizons.Builder.Props
             slideReelObj.SetActive(true);
 
             return slideReelObj;
+        }
+
+        private static GameObject GetSlideReelPrefab(ProjectionInfo.SlideReelType model, ProjectionInfo.SlideReelCondition condition)
+        {
+            switch (model)
+            {
+                case ProjectionInfo.SlideReelType.SixSlides:
+                {
+                    switch (condition)
+                    {
+                        case ProjectionInfo.SlideReelCondition.Antique:
+                        default:
+                            return SlideReel6Prefab;
+                        case ProjectionInfo.SlideReelCondition.Pristine:
+                            return SlideReel6PristinePrefab;
+                        case ProjectionInfo.SlideReelCondition.Rusted:
+                            return SlideReel6RustedPrefab;
+                    }
+                }
+                case ProjectionInfo.SlideReelType.SevenSlides:
+                default:
+                {
+                    switch (condition)
+                    {
+                        case ProjectionInfo.SlideReelCondition.Antique:
+                        default:
+                            return SlideReel7Prefab;
+                        case ProjectionInfo.SlideReelCondition.Pristine:
+                            return SlideReel7PristinePrefab;
+                        case ProjectionInfo.SlideReelCondition.Rusted:
+                            return SlideReel7RustedPrefab;
+                    }
+                }
+                case ProjectionInfo.SlideReelType.EightSlides:
+                {
+                    switch (condition)
+                    {
+                        case ProjectionInfo.SlideReelCondition.Antique:
+                        default:
+                            return SlideReel8Prefab;
+                        case ProjectionInfo.SlideReelCondition.Pristine:
+                            return SlideReel8PristinePrefab;
+                        case ProjectionInfo.SlideReelCondition.Rusted:
+                            return SlideReel8RustedPrefab;
+                    }
+                }
+                case ProjectionInfo.SlideReelType.Whole:
+                {
+                    switch (condition)
+                    {
+                        case ProjectionInfo.SlideReelCondition.Antique:
+                        default:
+                            return SlideReelWholePrefab;
+                        case ProjectionInfo.SlideReelCondition.Pristine:
+                            return SlideReelWholePristinePrefab;
+                        case ProjectionInfo.SlideReelCondition.Rusted:
+                            return SlideReelWholeRustedPrefab;
+                    }
+                }
+            }
+        }
+
+        private static string GetSlideReelName(ProjectionInfo.SlideReelType model, ProjectionInfo.SlideReelCondition condition)
+        {
+            switch (model)
+            {
+                case ProjectionInfo.SlideReelType.SixSlides:
+                    return $"6_{condition}";
+                case ProjectionInfo.SlideReelType.SevenSlides:
+                    return $"7_{condition}";
+                case ProjectionInfo.SlideReelType.EightSlides:
+                    return $"8_{condition}";
+                case ProjectionInfo.SlideReelType.Whole:
+                default:
+                    return $"{model}_{condition}";
+            }
         }
 
         public static GameObject MakeAutoProjector(GameObject planetGO, Sector sector, ProjectionInfo info, IModBehaviour mod)

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -251,7 +251,7 @@ namespace NewHorizons.Builder.Props
             }
         }
 
-        private static string GetSlideReelName(ProjectionInfo.SlideReelType model, ProjectionInfo.SlideReelCondition condition)
+        public static string GetSlideReelName(ProjectionInfo.SlideReelType model, ProjectionInfo.SlideReelCondition condition)
         {
             switch (model)
             {
@@ -264,6 +264,21 @@ namespace NewHorizons.Builder.Props
                 case ProjectionInfo.SlideReelType.Whole:
                 default:
                     return $"{model}_{condition}";
+            }
+        }
+
+        public static int GetSlideCount(ProjectionInfo.SlideReelType model)
+        {
+            switch (model)
+            {
+                case ProjectionInfo.SlideReelType.SixSlides:
+                    return 6;
+                case ProjectionInfo.SlideReelType.SevenSlides:
+                case ProjectionInfo.SlideReelType.Whole:
+                    return 7;
+                case ProjectionInfo.SlideReelType.EightSlides:
+                default:
+                    return 8;
             }
         }
 

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/ProjectionInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/ProjectionInfo.cs
@@ -21,6 +21,28 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
 
         }
 
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum SlideReelType
+        {
+            [EnumMember(Value = @"sixSlides")] SixSlides = 6,
+
+            [EnumMember(Value = @"sevenSlides")] SevenSlides = 7,
+
+            [EnumMember(Value = @"eightSlides")] EightSlides = 8,
+
+            [EnumMember(Value = @"whole")] Whole = 9,
+        }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum SlideReelCondition
+        {
+            [EnumMember(Value = @"antique")] Antique = 0,
+
+            [EnumMember(Value = @"pristine")] Pristine = 1,
+
+            [EnumMember(Value = @"rusted")] Rusted = 2,
+        }
+
         /// <summary>
         /// The ship log facts revealed after finishing this slide reel.
         /// </summary>
@@ -43,6 +65,16 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// The type of object this is.
         /// </summary>
         [DefaultValue("slideReel")] public SlideShowType type = SlideShowType.SlideReel;
+
+        /// <summary>
+        /// Exclusive to the slide reel type. Model/mesh of the reel. Each model has a different number of slides on it. Whole has 7 slides but a full ring like 8.
+        /// </summary>
+        [DefaultValue("sevenSlides")] public SlideReelType reelModel = SlideReelType.SevenSlides;
+
+        /// <summary>
+        /// Exclusive to the slide reel type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted is a burned reel.
+        /// </summary>
+        [DefaultValue("antique")] public SlideReelCondition reelCondition = SlideReelCondition.Antique;
     }
 
 }

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/SlideInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/SlideInfo.cs
@@ -84,5 +84,12 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// Set this to include ship log entry module. Base game default is "".
         /// </summary>
         public string reveal;
+
+        // SlideRotationModule
+
+        /// <summary>
+        /// Exclusive to slide reels. Whether this slide should rotate the reel item while inside a projector.
+        /// </summary>
+        public bool rotate = true;
     }
 }

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/SlideInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/SlideInfo.cs
@@ -90,6 +90,6 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// <summary>
         /// Exclusive to slide reels. Whether this slide should rotate the reel item while inside a projector.
         /// </summary>
-        public bool rotate = true;
+        [DefaultValue(true)] public bool rotate = true;
     }
 }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2183,7 +2183,8 @@
         },
         "rotate": {
           "type": "boolean",
-          "description": "Exclusive to slide reels. Whether this slide should rotate the reel item while inside a projector."
+          "description": "Exclusive to slide reels. Whether this slide should rotate the reel item while inside a projector.",
+          "default": true
         }
       }
     },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2180,6 +2180,10 @@
         "reveal": {
           "type": "string",
           "description": "Ship log fact revealed when viewing this slide.\nSet this to include ship log entry module. Base game default is \"\"."
+        },
+        "rotate": {
+          "type": "boolean",
+          "description": "Exclusive to slide reels. Whether this slide should rotate the reel item while inside a projector."
         }
       }
     },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2105,6 +2105,16 @@
           "description": "The type of object this is.",
           "default": "slideReel",
           "$ref": "#/definitions/SlideShowType"
+        },
+        "reelModel": {
+          "description": "Exclusive to the slide reel type. Model/mesh of the reel. Each model has a different number of slides on it. Whole has 7 slides but a full ring like 8.",
+          "default": "sevenSlides",
+          "$ref": "#/definitions/SlideReelType"
+        },
+        "reelCondition": {
+          "description": "Exclusive to the slide reel type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted is a burned reel.",
+          "default": "antique",
+          "$ref": "#/definitions/SlideReelCondition"
         }
       }
     },
@@ -2187,6 +2197,36 @@
         "autoProjector",
         "visionTorchTarget",
         "standingVisionTorch"
+      ]
+    },
+    "SlideReelType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "SixSlides",
+        "SevenSlides",
+        "EightSlides",
+        "Whole"
+      ],
+      "enum": [
+        "sixSlides",
+        "sevenSlides",
+        "eightSlides",
+        "whole"
+      ]
+    },
+    "SlideReelCondition": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Antique",
+        "Pristine",
+        "Rusted"
+      ],
+      "enum": [
+        "antique",
+        "pristine",
+        "rusted"
       ]
     },
     "QuantumGroupInfo": {


### PR DESCRIPTION
## Minor features

- New `reelModel` and `reelCondition` parameters in prop `slideShows` for slide reel mesh and material. (#811)
  - Models: 6-slided, 7-slided, 8-slided, and Whole (7-slided but connected like 8-slided).
  - Conditions: Antique (Stranger), Pristine (Dreamworld), Rusted (Burnt)
- `rotate` parameter added to slide info. Rotates the slide reel item while inside a projector.