### PR TITLE
Allow replacing ship log map mode icons of existing planets

### DIFF
--- a/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
@@ -7,19 +7,33 @@ using NewHorizons.Utility;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
+using OWML.ModHelper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
+using static NewHorizons.External.Modules.ShipLogModule;
 
 namespace NewHorizons.Builder.ShipLog
 {
     public static class MapModeBuilder
     {
+        // Takes the game object because sometimes we change the AO to an NHAO and it breaks
+        private static Dictionary<GameObject, ShipLogAstroObject> _astroObjectToShipLog = new();
+
         #region General
         public static ShipLogAstroObject[][] ConstructMapMode(string systemName, GameObject transformParent, ShipLogAstroObject[][] currentNav, int layer)
         {
+            _astroObjectToShipLog = new();
+
+            // Add stock planets
+            foreach (var shipLogAstroObject in currentNav.SelectMany(x => x))
+            {
+                var astroObject = Locator.GetAstroObject(AstroObject.StringIDToAstroObjectName(shipLogAstroObject._id));
+                _astroObjectToShipLog[astroObject.gameObject] = shipLogAstroObject;
+            }
+
             Material greyScaleMaterial = SearchUtilities.Find(ShipLogHandler.PAN_ROOT_PATH + "/TimberHearth/Sprite").GetComponent<Image>().material;
             List<NewHorizonsBody> bodies = Main.BodyDict[systemName].Where(
                 b => !(b.Config.ShipLog?.mapMode?.remove ?? false) && !b.Config.isQuantumState
@@ -71,16 +85,20 @@ namespace NewHorizons.Builder.ShipLog
                 }
             }
 
+            ShipLogAstroObject[][] newNavMatrix = null;
+
             if (useAuto)
             {
-                return ConstructMapModeAuto(bodies, transformParent, greyScaleMaterial, layer);
+                newNavMatrix = ConstructMapModeAuto(bodies, transformParent, greyScaleMaterial, layer);
             }
             else if (useManual)
             {
-                return ConstructMapModeManual(bodies, transformParent, greyScaleMaterial, currentNav, layer);
+                newNavMatrix = ConstructMapModeManual(bodies, transformParent, greyScaleMaterial, currentNav, layer);
             }
 
-            return null;
+            ReplaceExistingMapModeIcons();
+
+            return newNavMatrix;
         }
 
         public static string GetAstroBodyShipLogName(string id)
@@ -133,6 +151,7 @@ namespace NewHorizons.Builder.ShipLog
 
             ShipLogAstroObject astroObject = gameObject.AddComponent<ShipLogAstroObject>();
             astroObject._id = ShipLogHandler.GetAstroObjectId(body);
+            _astroObjectToShipLog[body.Object] = astroObject;
 
             Texture2D image = null;
             Texture2D outline = null;
@@ -604,5 +623,68 @@ namespace NewHorizons.Builder.ShipLog
 
             return Color.white;
         }
+
+        #region Replacement
+        private static List<(NewHorizonsBody, ModBehaviour, MapModeInfo)> _mapModIconsToUpdate = new();
+        public static void TryReplaceExistingMapModeIcon(NewHorizonsBody body, ModBehaviour mod, MapModeInfo info)
+        {
+            if (!string.IsNullOrEmpty(info.revealedSprite) || !string.IsNullOrEmpty(info.outlineSprite))
+            {
+                _mapModIconsToUpdate.Add((body, mod, info));
+            }
+        }
+
+        private static void ReplaceExistingMapModeIcons()
+        {
+            foreach (var (body, mod, info) in _mapModIconsToUpdate)
+            {
+                ReplaceExistingMapModeIcon(body, mod, info);
+            }
+            _mapModIconsToUpdate.Clear();
+        }
+
+        private static void ReplaceExistingMapModeIcon(NewHorizonsBody body, ModBehaviour mod, MapModeInfo info)
+        { 
+            var astroObject = _astroObjectToShipLog[body.Object];
+            var gameObject = astroObject.gameObject;
+            var layer = gameObject.layer;
+
+            if (!string.IsNullOrEmpty(info.revealedSprite))
+            {
+                var revealedTexture = ImageUtilities.GetTexture(body.Mod, info.revealedSprite);
+                if (revealedTexture == null)
+                {
+                    NHLogger.LogError($"Couldn't load replacement revealed texture {info.revealedSprite}");
+                }
+                else
+                {
+                    GameObject.Destroy(astroObject._imageObj);
+                    if (ShipLogHandler.IsVanillaBody(body) || ShipLogHandler.BodyHasEntries(body))
+                    {
+                        Image revealedImage = astroObject._imageObj.GetComponent<Image>();
+                        revealedImage.material = astroObject._greyscaleMaterial;
+                        revealedImage.color = Color.white;
+                        astroObject._image = revealedImage;
+                    }
+                    astroObject._imageObj = CreateImage(gameObject, revealedTexture, body.Config.name + " Revealed", layer);
+                }
+            }
+            if (!string.IsNullOrEmpty(info.outlineSprite))
+            {
+                var outlineTexture = ImageUtilities.GetTexture(body.Mod, info.outlineSprite);
+                if (outlineTexture == null)
+                {
+                    NHLogger.LogError($"Couldn't load replacement outline texture {info.outlineSprite}");
+
+                }
+                else
+                {
+                    GameObject.Destroy(astroObject._outlineObj);
+                    astroObject._outlineObj = CreateImage(gameObject, outlineTexture, body.Config.name + " Outline", layer);
+                }
+            }
+            astroObject._invisibleWhenHidden = info.invisibleWhenHidden;
+        }
+        #endregion
     }
 }

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -3,22 +3,23 @@ using NewHorizons.Builder.Body;
 using NewHorizons.Builder.General;
 using NewHorizons.Builder.Orbital;
 using NewHorizons.Builder.Props;
+using NewHorizons.Builder.ShipLog;
 using NewHorizons.Builder.Volumes;
 using NewHorizons.Components.Orbital;
 using NewHorizons.Components.Quantum;
 using NewHorizons.Components.Stars;
 using NewHorizons.External;
 using NewHorizons.OtherMods.OWRichPresence;
+using NewHorizons.Streaming;
 using NewHorizons.Utility;
-using NewHorizons.Utility.OWML;
 using NewHorizons.Utility.OuterWilds;
+using NewHorizons.Utility.OWML;
+using Newtonsoft.Json;
+using OWML.ModHelper;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using NewHorizons.Streaming;
-using Newtonsoft.Json;
-using NewHorizons.External.Modules.VariableSize;
 
 namespace NewHorizons.Handlers
 {
@@ -343,6 +344,13 @@ namespace NewHorizons.Handlers
 
             // Do stuff that's shared between generating new planets and updating old ones
             go = SharedGenerateBody(body, go, sector, rb);
+
+            if (body.Config.ShipLog?.mapMode != null)
+            {
+                MapModeBuilder.TryReplaceExistingMapModeIcon(body, body.Mod as ModBehaviour, body.Config.ShipLog.mapMode);
+            }
+
+            body.Object = go;
 
             return go;
         }


### PR DESCRIPTION
## Improvements
- Map mode icon setting changes now work when updating an existing planet. Fixes #875