### PR TITLE
1.22.1

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -166,8 +166,8 @@ namespace NewHorizons.Builder.Props
                     (Texture2D tex, int _, string originalPath) =>
                     {
                         // all textures required to build the reel's textures have been loaded
-                        var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Back").GetComponent<MeshRenderer>();
-                        var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Front").GetComponent<MeshRenderer>();
+                        var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Back").GetComponent<MeshRenderer>();
+                        var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Front").GetComponent<MeshRenderer>();
 
                         // Now put together the textures into a 4x4 thing for the materials
                         var reelTexture = tex;
@@ -202,8 +202,8 @@ namespace NewHorizons.Builder.Props
                         if (displaySlidesLoaded == textures.Length)
                         {
                             // all textures required to build the reel's textures have been loaded
-                            var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Back").GetComponent<MeshRenderer>();
-                            var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>().transform.Find("Slides_Front").GetComponent<MeshRenderer>();
+                            var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Back").GetComponent<MeshRenderer>();
+                            var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Front").GetComponent<MeshRenderer>();
 
                             // Now put together the textures into a 4x4 thing for the materials
                             var reelTexture = ImageUtilities.MakeReelTexture(mod, textures, key);

--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -5,7 +5,6 @@ using NewHorizons.Builder.ShipLog;
 using NewHorizons.External;
 using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
-using NewHorizons.External.Modules.Props.Dialogue;
 using NewHorizons.Utility;
 using NewHorizons.Utility.OWML;
 using OWML.Common;

--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -5,6 +5,7 @@ using NewHorizons.Builder.ShipLog;
 using NewHorizons.External;
 using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
+using NewHorizons.External.Modules.Props.Dialogue;
 using NewHorizons.Utility;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
@@ -79,15 +80,15 @@ namespace NewHorizons.Builder.Props
                 nextPass.Clear();
                 passClone.ForEach((x) => x.Invoke());
 
-                if (nextPass.Count >= count)
+                if (nextPass.Count >= count || i++ > 10)
                 {
-                    NHLogger.LogError("Couldn't find any parents");
-                    break;
-                }
+                    NHLogger.LogError("Couldn't find any parents. Did you write an invalid parent path?");
 
-                if (i++ > 10)
-                {
-                    NHLogger.LogError("Went through more than 10 passes of trying to find parents, stopping");
+                    // Ignore the parent this time so that other error handling stuff can deal with these invalid paths like it used to (backwards compat)
+                    _ignoreParent = true;
+                    nextPass.ForEach((x) => x.Invoke());
+                    _ignoreParent = false;
+
                     break;
                 }
             }
@@ -180,9 +181,15 @@ namespace NewHorizons.Builder.Props
             }
         }
 
+        private static bool _ignoreParent;
+
         private static bool DoesParentExist(GameObject go, BasePropInfo prop)
         {
-            if (string.IsNullOrEmpty(prop.parentPath))
+            if (_ignoreParent)
+            {
+                return true;
+            }
+            else if (string.IsNullOrEmpty(prop.parentPath))
             {
                 return true;
             }

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes

- Fix an NRE that affected Astral Codec
- Undo a change that made NH stop creating props if their parent path was invalid (will revert to whatever the old behaviour was; using root sector or dialogue anim controller). Affected Astral Codec.
