### PR TITLE
Fix inactive signals being used with signalscope strongest signal method

### DIFF
--- a/NewHorizons/Patches/LocatorPatches.cs
+++ b/NewHorizons/Patches/LocatorPatches.cs
@@ -1,4 +1,6 @@
 using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NewHorizons.Patches
 {
@@ -107,6 +109,13 @@ namespace NewHorizons.Patches
             _hollowsLantern = null;
             _mapSatellite = null;
             _sunStation = null;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(Locator.GetAudioSignals))]
+        public static void Locator_GetAudioSignals(ref List<AudioSignal> __result)
+        {
+            __result = __result.Where(signal => signal.IsActive()).ToList();
         }
     }
 }

--- a/NewHorizons/Patches/SignalPatches/AudioSignalPatches.cs
+++ b/NewHorizons/Patches/SignalPatches/AudioSignalPatches.cs
@@ -11,6 +11,13 @@ namespace NewHorizons.Patches.SignalPatches
     [HarmonyPatch(typeof(AudioSignal))]
     public static class AudioSignalPatches
     {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(AudioSignal.IsActive))]
+        public static void AudioSignal_IsActive(AudioSignal __instance, ref bool __result)
+        {
+            __result = __result && __instance.gameObject.activeInHierarchy;
+        }
+
         [HarmonyPrefix]
         [HarmonyPatch(nameof(AudioSignal.SignalNameToString))]
         public static bool AudioSignal_SignalNameToString(SignalName name, ref string __result)


### PR DESCRIPTION
## Bug fixes

- Fix inactive signals being used with signalscope strongest signal method. This bug prevented some vanilla frequencies from showing up in custom systems.