### PR TITLE
Fix documentation error and add log for future debuging for QueryBody; Set SolarSystem relative path if a mod adds a .json file to overwrite it.

### DIFF
--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -694,14 +694,26 @@ namespace NewHorizons
 
             if (SystemDict.ContainsKey(starSystemName))
             {
+                // Both changing the Mod and RelativePath are weird and will likely cause incompat issues if two mods both affected the same system
+                // It's mostly just to fix up the config compared to the default one NH makes for the base StarSystem
+
                 if (SystemDict[starSystemName].Config.GlobalMusic == null && SystemDict[starSystemName].Config.Skybox == null)
+                {
                     SystemDict[starSystemName].Mod = mod;
-                if (SystemDict[starSystemName].Config.extras == null)
-                    SystemDict[starSystemName].RelativePath = relativePath;
-                SystemDict[starSystemName].Config.Merge(starSystemConfig);
+                }
+
                 // If a mod contains a change to the default system, set the relative path.
                 // Warning: If multiple systems make changes to the default system, only the relativePath will be set to the last mod loaded.
-                SystemDict[starSystemName].RelativePath = relativePath;
+                if (string.IsNullOrEmpty(SystemDict[starSystemName].RelativePath))
+                {
+                    SystemDict[starSystemName].RelativePath = relativePath;
+                }
+                else
+                {
+                    NHLogger.LogWarning($"Two (or more) mods are making system changes to {starSystemName} which may result in errors");
+                }
+
+                SystemDict[starSystemName].Config.Merge(starSystemConfig);
             }
             else
             {

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -695,6 +695,9 @@ namespace NewHorizons
                 if (SystemDict[starSystemName].Config.GlobalMusic == null && SystemDict[starSystemName].Config.Skybox == null)
                     SystemDict[starSystemName].Mod = mod;
                 SystemDict[starSystemName].Config.Merge(starSystemConfig);
+                // If a mod contains a change to the default system, set the relative path.
+                // Warning: If multiple systems make changes to the default system, only the relativePath will be set to the last mod loaded.
+                SystemDict[starSystemName].RelativePath = relativePath;
             }
             else
             {

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -143,9 +143,11 @@ namespace NewHorizons
         public object QueryBody(Type outType, string bodyName, string jsonPath)
         {
             var planet = Main.BodyDict[Main.Instance.CurrentStarSystem].Find((b) => b.Config.name == bodyName);
-            return planet == null
-                ? null
-                : QueryJson(outType, Path.Combine(planet.Mod.ModHelper.Manifest.ModFolderPath, planet.RelativePath), jsonPath);
+            if (planet == null){
+				NHLogger.LogError($"Could not find planet with body name {bodyName}.")
+				return null;
+			}
+			return QueryJson(outType, Path.Combine(planet.Mod.ModHelper.Manifest.ModFolderPath, planet.RelativePath), jsonPath);
         }
 
         public T QueryBody<T>(string bodyName, string jsonPath)

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -163,7 +163,6 @@ namespace NewHorizons
         public object QuerySystem(Type outType, string jsonPath)
         {
             var system = Main.SystemDict[Main.Instance.CurrentStarSystem];
-            NHLogger.Log("System Relative Path: " + system.RelativePath);
             return system == null
                 ? null
                 : QueryJson(outType, Path.Combine(system.Mod.ModHelper.Manifest.ModFolderPath, system.RelativePath), jsonPath);

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -144,7 +144,7 @@ namespace NewHorizons
         {
             var planet = Main.BodyDict[Main.Instance.CurrentStarSystem].Find((b) => b.Config.name == bodyName);
             if (planet == null){
-				NHLogger.LogError($"Could not find planet with body name {bodyName}.")
+                NHLogger.LogError($"Could not find planet with body name {bodyName}.");
 				return null;
 			}
 			return QueryJson(outType, Path.Combine(planet.Mod.ModHelper.Manifest.ModFolderPath, planet.RelativePath), jsonPath);
@@ -163,6 +163,7 @@ namespace NewHorizons
         public object QuerySystem(Type outType, string jsonPath)
         {
             var system = Main.SystemDict[Main.Instance.CurrentStarSystem];
+            NHLogger.Log("System Relative Path: " + system.RelativePath);
             return system == null
                 ? null
                 : QueryJson(outType, Path.Combine(system.Mod.ModHelper.Manifest.ModFolderPath, system.RelativePath), jsonPath);

--- a/docs/src/content/docs/guides/extending-configs.md
+++ b/docs/src/content/docs/guides/extending-configs.md
@@ -49,7 +49,7 @@ Then, use the `QueryBody` method:
 var api = ModHelper.Interactions.TryGetModApi<INewHorizons>("xen.NewHorizons");
 api.GetBodyLoadedEvent().AddListener((name) => {
     ModHelper.Console.WriteLine($"Body: {name} Loaded!");
-    var data = api.QueryBody<MyCoolExtensionData>("$.extras.myCoolExtensionData", name);
+    var data = api.QueryBody<MyCoolExtensionData>(name, "$.extras.myCoolExtensionData");
     // Makes sure the module is not null
     if (data != null) {
         ModHelper.Console.WriteLine($"myCoolExtensionProperty for {name} is {data.myCoolExtensionProperty}!");


### PR DESCRIPTION

<!-- Be sure to reference the existing issue if it exists -->

## Bug fixes

- Added log message in the event the QueryBody could not find a body
- Fixed documentation to match API
- Discovered that if you modify the default SolarySystem, `QuerySystem` will fail due to an IO error as the relative path is not set. While not an ideal solution, we have settled on just setting the relativePath if a mod adjusts the system. This will mean that the last mod loaded that makes these changes will have set the relative path. 
