### PR TITLE
Can warp home

### DIFF
--- a/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
+++ b/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
@@ -96,7 +96,7 @@ namespace NewHorizons.Components.ShipLog
             if (_cardTemplate == null)
             {
                 var panRoot = SearchUtilities.Find("Ship_Body/Module_Cabin/Systems_Cabin/ShipLogPivot/ShipLog/ShipLogPivot/ShipLogCanvas/DetectiveMode/ScaleRoot/PanRoot");
-                _cardTemplate = Instantiate(panRoot.GetComponentInChildren<ShipLogEntryCard>().gameObject);
+                _cardTemplate = Instantiate(panRoot.GetComponentInChildren<ShipLogEntryCard>(true).gameObject);
                 _cardTemplate.SetActive(false);
             }
 
@@ -209,6 +209,12 @@ namespace NewHorizons.Components.ShipLog
 
         private void UpdateMapCamera()
         {
+            if (_starSystemCards.Count == 0)
+            {
+                NHLogger.LogWarning("Showing star chart mode when there are no avaialble systems");
+                return;
+            }
+
             Vector2 b = -_starSystemCards[_cardIndex].transform.localPosition;
             float num = Mathf.InverseLerp(_startPanTime, _startPanTime + _panDuration, Time.unscaledTime);
             num = 1f - (num - 1f) * (num - 1f);

--- a/NewHorizons/External/Configs/StarSystemConfig.cs
+++ b/NewHorizons/External/Configs/StarSystemConfig.cs
@@ -33,7 +33,7 @@ namespace NewHorizons.External.Configs
 
         /// <summary>
         /// Whether this system can be warped to via the warp drive. If you set `factRequiredForWarp`, this will be true.
-        /// Does NOT effect the base SolarSystem. For that, see `canWarpHome` and `factRequiredForWarpHome`
+        /// Does NOT effect the base SolarSystem. For that, see `canExitViaWarpDrive` and `factRequiredToExitViaWarpDrive`
         /// </summary>
         [DefaultValue(true)] public bool canEnterViaWarpDrive = true;
 
@@ -44,16 +44,16 @@ namespace NewHorizons.External.Configs
         public string factRequiredForWarp;
 
         /// <summary>
-        /// Can you use the warp drive to return home to the Outer Wilds from this system? If you set `factRequiredForWarpHome`
+        /// Can you use the warp drive to leave this system? If you set `factRequiredToExitViaWarpDrive`
         /// this will be true.
         /// </summary>
-        [DefaultValue(true)] public bool canWarpHome = true;
+        [DefaultValue(true)] public bool canExitViaWarpDrive = true;
 
         /// <summary>
         /// The FactID that must be revealed for you to warp back to the main solar system from here. Don't set `canWarpHome`
         /// to `false` if you're using this, because it will be overwritten.
         /// </summary>
-        public string factRequiredForWarpHome;
+        public string factRequiredToExitViaWarpDrive;
 
         /// <summary>
         /// Do you want a clean slate for this star system? Or will it be a modified version of the original.
@@ -428,9 +428,9 @@ namespace NewHorizons.External.Configs
                     Vessel.warpExit.attachToVessel = true;
                 }
             }
-            if (!string.IsNullOrEmpty(factRequiredForWarpHome))
+            if (!string.IsNullOrEmpty(factRequiredToExitViaWarpDrive))
             {
-                canWarpHome = true;
+                canExitViaWarpDrive = true;
             }
         }
     }

--- a/NewHorizons/External/Configs/StarSystemConfig.cs
+++ b/NewHorizons/External/Configs/StarSystemConfig.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Xml;
 using NewHorizons.External.Modules;
 using NewHorizons.External.SerializableData;
 using Newtonsoft.Json;
@@ -31,9 +32,28 @@ namespace NewHorizons.External.Configs
         public float farClipPlaneOverride;
 
         /// <summary>
-        /// Whether this system can be warped to via the warp drive. If you set factRequiredForWarp, this will be true.
+        /// Whether this system can be warped to via the warp drive. If you set `factRequiredForWarp`, this will be true.
+        /// Does NOT effect the base SolarSystem. For that, see `canWarpHome` and `factRequiredForWarpHome`
         /// </summary>
         [DefaultValue(true)] public bool canEnterViaWarpDrive = true;
+
+        /// <summary>
+        /// The FactID that must be revealed before it can be warped to. Don't set `canEnterViaWarpDrive` to `false` if
+        /// you're using this, because it will be overwritten.
+        /// </summary>
+        public string factRequiredForWarp;
+
+        /// <summary>
+        /// Can you use the warp drive to return home to the Outer Wilds from this system? If you set `factRequiredForWarpHome`
+        /// this will be true.
+        /// </summary>
+        [DefaultValue(true)] public bool canWarpHome = true;
+
+        /// <summary>
+        /// The FactID that must be revealed for you to warp back to the main solar system from here. Don't set `canWarpHome`
+        /// to `false` if you're using this, because it will be overwritten.
+        /// </summary>
+        public string factRequiredForWarpHome;
 
         /// <summary>
         /// Do you want a clean slate for this star system? Or will it be a modified version of the original.
@@ -44,12 +64,6 @@ namespace NewHorizons.External.Configs
         /// Should the time loop be enabled in this system?
         /// </summary>
         [DefaultValue(true)] public bool enableTimeLoop = true;
-
-        /// <summary>
-        /// The FactID that must be revealed before it can be warped to. Don't set `canEnterViaWarpDrive` to `false` if
-        /// you're using this, because it will be overwritten.
-        /// </summary>
-        public string factRequiredForWarp;
 
         /// <summary>
         /// The duration of the time loop in minutes. This is the time the sun explodes. End Times plays 85 seconds before this time, and your memories get sent back about 40 seconds after this time.
@@ -413,6 +427,10 @@ namespace NewHorizons.External.Configs
                     Vessel.warpExit.rotation ??= Vessel.warpExitRotation;
                     Vessel.warpExit.attachToVessel = true;
                 }
+            }
+            if (!string.IsNullOrEmpty(factRequiredForWarpHome))
+            {
+                canWarpHome = true;
             }
         }
     }

--- a/NewHorizons/External/NewHorizonsSystem.cs
+++ b/NewHorizons/External/NewHorizonsSystem.cs
@@ -24,7 +24,7 @@ namespace NewHorizons.External
             // Backwards compat
             if (new string[] { "2walker2.OogaBooga", "2walker2.EndingIfYouWarpHereYouAreMean", "FeldsparSystem" }.Contains(uniqueID))
             {
-                config.canWarpHome = false;
+                config.canExitViaWarpDrive = false;
             }
         }
     }

--- a/NewHorizons/External/NewHorizonsSystem.cs
+++ b/NewHorizons/External/NewHorizonsSystem.cs
@@ -1,6 +1,7 @@
 using NewHorizons.External.Configs;
 using NewHorizons.External.Modules;
 using OWML.Common;
+using System.Linq;
 
 namespace NewHorizons.External
 {
@@ -19,6 +20,12 @@ namespace NewHorizons.External
             Config = config;
             RelativePath = relativePath;
             Mod = mod;
+
+            // Backwards compat
+            if (new string[] { "2walker2.OogaBooga", "2walker2.EndingIfYouWarpHereYouAreMean", "FeldsparSystem" }.Contains(uniqueID))
+            {
+                config.canWarpHome = false;
+            }
         }
     }
 }

--- a/NewHorizons/Handlers/StarChartHandler.cs
+++ b/NewHorizons/Handlers/StarChartHandler.cs
@@ -59,6 +59,8 @@ namespace NewHorizons.Handlers
             _starSystemToFactID = new Dictionary<string, string>();
             _factIDToStarSystem = new Dictionary<string, string>();
 
+            _factRequiredToExitViaWarpDrive = string.Empty;
+
             foreach (NewHorizonsSystem system in _systems)
             {
                 if (system.Config.factRequiredForWarp != default && system.UniqueID != "SolarSystem")
@@ -112,8 +114,8 @@ namespace NewHorizons.Handlers
             return ShipLogHandler.KnowsFact(factID);
         }
 
-        public static bool CanExitViaWarpDrive() => _canExitViaWarpDrive
-                && (string.IsNullOrEmpty(_factRequiredToExitViaWarpDrive) || ShipLogHandler.KnowsFact(_factRequiredToExitViaWarpDrive));
+        public static bool CanExitViaWarpDrive() => Main.Instance.CurrentStarSystem == "SolarSystem" || (_canExitViaWarpDrive
+                && (string.IsNullOrEmpty(_factRequiredToExitViaWarpDrive) || ShipLogHandler.KnowsFact(_factRequiredToExitViaWarpDrive)));
 
         /// <summary>
         /// Is it actually a valid warp target

--- a/NewHorizons/Handlers/StarChartHandler.cs
+++ b/NewHorizons/Handlers/StarChartHandler.cs
@@ -58,9 +58,14 @@ namespace NewHorizons.Handlers
 
             foreach (NewHorizonsSystem system in _systems)
             {
-                if (system.Config.factRequiredForWarp != default)
+                if (system.Config.factRequiredForWarp != default && system.UniqueID != "SolarSystem")
                 {
                     RegisterFactForSystem(system.Config.factRequiredForWarp, system.UniqueID);
+                }
+
+                if (system.UniqueID == Main.Instance.CurrentStarSystem && !string.IsNullOrEmpty(system.Config.factRequiredForWarpHome))
+                {
+                    RegisterFactForSystem(system.Config.factRequiredForWarpHome, "SolarSystem");
                 }
             }
         }
@@ -113,8 +118,16 @@ namespace NewHorizons.Handlers
             else if (system.Equals("EyeOfTheUniverse")) canWarpTo = false;
             else if (config.Spawn?.shipSpawn != null) canWarpTo = true;
 
+            var canEnterViaWarpDrive = Main.SystemDict[system].Config.canEnterViaWarpDrive;
+
+            // For the base solar system, use canWarpHome instead for better mod compat
+            if (system.Equals("SolarSystem"))
+            {
+                canEnterViaWarpDrive = Main.SystemDict[Main.Instance.CurrentStarSystem].Config.canWarpHome;
+            }
+
             return canWarpTo
-                    && Main.SystemDict[system].Config.canEnterViaWarpDrive
+                    && canEnterViaWarpDrive
                     && system != Main.Instance.CurrentStarSystem
                     && HasUnlockedSystem(system);
         }

--- a/NewHorizons/Schemas/star_system_schema.json
+++ b/NewHorizons/Schemas/star_system_schema.json
@@ -20,8 +20,21 @@
     },
     "canEnterViaWarpDrive": {
       "type": "boolean",
-      "description": "Whether this system can be warped to via the warp drive. If you set factRequiredForWarp, this will be true.",
+      "description": "Whether this system can be warped to via the warp drive. If you set `factRequiredForWarp`, this will be true.\nDoes NOT effect the base SolarSystem. For that, see `canWarpHome` and `factRequiredForWarpHome`",
       "default": true
+    },
+    "factRequiredForWarp": {
+      "type": "string",
+      "description": "The FactID that must be revealed before it can be warped to. Don't set `canEnterViaWarpDrive` to `false` if\nyou're using this, because it will be overwritten."
+    },
+    "canWarpHome": {
+      "type": "boolean",
+      "description": "Can you use the warp drive to return home to the Outer Wilds from this system? If you set `factRequiredForWarpHome`\nthis will be true.",
+      "default": true
+    },
+    "factRequiredForWarpHome": {
+      "type": "string",
+      "description": "The FactID that must be revealed for you to warp back to the main solar system from here. Don't set `canWarpHome`\nto `false` if you're using this, because it will be overwritten."
     },
     "destroyStockPlanets": {
       "type": "boolean",
@@ -32,10 +45,6 @@
       "type": "boolean",
       "description": "Should the time loop be enabled in this system?",
       "default": true
-    },
-    "factRequiredForWarp": {
-      "type": "string",
-      "description": "The FactID that must be revealed before it can be warped to. Don't set `canEnterViaWarpDrive` to `false` if\nyou're using this, because it will be overwritten."
     },
     "loopDuration": {
       "type": "number",

--- a/NewHorizons/Schemas/star_system_schema.json
+++ b/NewHorizons/Schemas/star_system_schema.json
@@ -20,19 +20,19 @@
     },
     "canEnterViaWarpDrive": {
       "type": "boolean",
-      "description": "Whether this system can be warped to via the warp drive. If you set `factRequiredForWarp`, this will be true.\nDoes NOT effect the base SolarSystem. For that, see `canWarpHome` and `factRequiredForWarpHome`",
+      "description": "Whether this system can be warped to via the warp drive. If you set `factRequiredForWarp`, this will be true.\nDoes NOT effect the base SolarSystem. For that, see `canExitViaWarpDrive` and `factRequiredToExitViaWarpDrive`",
       "default": true
     },
     "factRequiredForWarp": {
       "type": "string",
       "description": "The FactID that must be revealed before it can be warped to. Don't set `canEnterViaWarpDrive` to `false` if\nyou're using this, because it will be overwritten."
     },
-    "canWarpHome": {
+    "canExitViaWarpDrive": {
       "type": "boolean",
-      "description": "Can you use the warp drive to return home to the Outer Wilds from this system? If you set `factRequiredForWarpHome`\nthis will be true.",
+      "description": "Can you use the warp drive to leave this system? If you set `factRequiredToExitViaWarpDrive`\nthis will be true.",
       "default": true
     },
-    "factRequiredForWarpHome": {
+    "factRequiredToExitViaWarpDrive": {
       "type": "string",
       "description": "The FactID that must be revealed for you to warp back to the main solar system from here. Don't set `canWarpHome`\nto `false` if you're using this, because it will be overwritten."
     },

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.22.5",
+  "version": "1.22.6",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Minor features

- Added `canExitViaWarpDrive` and `factRequiredToExitViaWarpDrive` to enable/disable warping out of your own system. Replaces setting `canEnterViaWarpDrive = false` on the base solar system (which now does nothing). Fixes compatibility between Astral Codec and anything that uses the warp drive.