### PR TITLE
Multiple fixes

### DIFF
--- a/NewHorizons/Builder/Atmosphere/AirBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/AirBuilder.cs
@@ -22,7 +22,7 @@ namespace NewHorizons.Builder.Atmosphere
             sfv._priority = 0;
             sfv._density = 1.2f;
             sfv._fluidType = FluidVolume.Type.AIR;
-            sfv._allowShipAutoroll = true;
+            sfv._allowShipAutoroll = config.Atmosphere.allowShipAutoroll;
             sfv._disableOnStart = false;
 
             if (config.Atmosphere.hasShockLayer)

--- a/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
+++ b/NewHorizons/Builder/Atmosphere/CloudsBuilder.cs
@@ -147,7 +147,7 @@ namespace NewHorizons.Builder.Atmosphere
             fluidCLFV._priority = 1;
             fluidCLFV._density = 1.2f;
             fluidCLFV._fluidType = atmo.clouds.fluidType.ConvertToOW(FluidVolume.Type.CLOUD);
-            fluidCLFV._allowShipAutoroll = true;
+            fluidCLFV._allowShipAutoroll = atmo.allowShipAutoroll;
             fluidCLFV._disableOnStart = false;
 
             // Fix the rotations once the rest is done

--- a/NewHorizons/Builder/Body/ProxyBuilder.cs
+++ b/NewHorizons/Builder/Body/ProxyBuilder.cs
@@ -96,6 +96,12 @@ namespace NewHorizons.Builder.Body
                 // We want to take the largest size I think
                 var realSize = body.Config.Base.surfaceSize;
 
+                if (realSize <= 0)
+                {
+                    // #941 handle proxy body edge case when all scales = 0
+                    realSize = 1;
+                }
+
                 if (body.Config.HeightMap != null)
                 {
                     HeightMapBuilder.Make(proxy, null, body.Config.HeightMap, body.Mod, 20);

--- a/NewHorizons/Builder/Body/WaterBuilder.cs
+++ b/NewHorizons/Builder/Body/WaterBuilder.cs
@@ -129,7 +129,7 @@ namespace NewHorizons.Builder.Body
             fluidVolume._density = module.density;
             fluidVolume._layer = 5;
             fluidVolume._priority = 3;
-            fluidVolume._allowShipAutoroll = true;
+            fluidVolume._allowShipAutoroll = module.allowShipAutoroll;
             fluidVolume._disableOnStart = false;
 
             var fogGO = Object.Instantiate(_oceanFog, waterGO.transform);

--- a/NewHorizons/Builder/General/AstroObjectBuilder.cs
+++ b/NewHorizons/Builder/General/AstroObjectBuilder.cs
@@ -8,6 +8,8 @@ namespace NewHorizons.Builder.General
 {
     public static class AstroObjectBuilder
     {
+        public static GameObject CenterOfUniverse { get; private set; }
+
         public static NHAstroObject Make(GameObject body, AstroObject primaryBody, NewHorizonsBody nhBody, bool isVanilla)
         {
             NHAstroObject astroObject = body.AddComponent<NHAstroObject>();
@@ -62,6 +64,8 @@ namespace NewHorizons.Builder.General
 
             if (config.Base.centerOfSolarSystem)
             {
+                CenterOfUniverse = body;
+
                 NHLogger.Log($"Setting center of universe to {config.name}");
 
                 Delay.RunWhen(

--- a/NewHorizons/Builder/General/AstroObjectBuilder.cs
+++ b/NewHorizons/Builder/General/AstroObjectBuilder.cs
@@ -19,7 +19,7 @@ namespace NewHorizons.Builder.General
 
             astroObject.isVanilla = isVanilla;
             astroObject.HideDisplayName = !config.MapMarker.enabled;
-            astroObject.invulnerableToSun = config.Base.invulnerableToSun;
+            astroObject.invulnerableToSun = !config.Base.hasFluidDetector;
 
             if (config.Orbit != null) astroObject.SetOrbitalParametersFromConfig(config.Orbit);
 

--- a/NewHorizons/Builder/General/DetectorBuilder.cs
+++ b/NewHorizons/Builder/General/DetectorBuilder.cs
@@ -90,7 +90,7 @@ namespace NewHorizons.Builder.General
             OWRB.RegisterAttachedForceDetector(forceDetector);
 
             // For falling into sun
-            if (!config.Base.invulnerableToSun && config.Star == null && config.FocalPoint == null)
+            if (config.Base.hasFluidDetector && config.Star == null && config.FocalPoint == null)
             {
                 detectorGO.layer = Layer.AdvancedDetector;
 

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -4,6 +4,7 @@ using NewHorizons.Utility;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
 using System;
+using System.Collections;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -87,8 +88,22 @@ namespace NewHorizons.Builder.General
                         handler.Method.Invoke(handler.Target, new object[] { command });
                     }
                     spv._interactVolume._listInteractions.First(x => x.promptText == UITextType.SuitUpPrompt).interactionEnabled = true;
+
+                    // Fix Disappearing Signalscope UI #934 after warping to new system wearing suit
+                    Delay.StartCoroutine(SignalScopeZoomCoroutine());
                 }
             }
+        }
+
+        private static IEnumerator SignalScopeZoomCoroutine()
+        {
+            while (!Locator.GetToolModeSwapper().GetSignalScope().InZoomMode())
+            {
+                yield return new WaitForEndOfFrame();
+            }
+            yield return null;
+            Locator.GetToolModeSwapper().GetSignalScope().ExitSignalscopeZoom();
+            Locator.GetToolModeSwapper().GetSignalScope().EnterSignalscopeZoom();
         }
     }
 }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -1,5 +1,6 @@
 using NewHorizons.Builder.General;
 using NewHorizons.Components;
+using NewHorizons.Components.Orbital;
 using NewHorizons.Components.Props;
 using NewHorizons.External.Modules.Props;
 using NewHorizons.Handlers;
@@ -374,6 +375,12 @@ namespace NewHorizons.Builder.Props
             // Fix anglerfish speed on orbiting planets
             else if (component is AnglerfishController angler)
             {
+                if (planetGO?.GetComponent<NHAstroObject>() is NHAstroObject nhao && !nhao.invulnerableToSun)
+                {
+                    // Has a fluid detector, will go gorp (#830)
+                    NHLogger.LogWarning("Having an anglerfish on a planet that has a fluid detector can lead to things breaking!");
+                }
+
                 try
                 {
                     angler._chaseSpeed += OWPhysics.CalculateOrbitVelocity(planetGO.GetAttachedOWRigidbody(), planetGO.GetComponent<AstroObject>().GetPrimaryBody().GetAttachedOWRigidbody()).magnitude;

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -67,6 +67,8 @@ namespace NewHorizons.Builder.Props
         /// </summary>
         public static GameObject Make(GameObject planetGO, Sector sector, IModBehaviour mod, DetailInfo info)
         {
+            if (sector == null) info.keepLoaded = true;
+
             if (info.assetBundle != null)
             {
                 // Shouldn't happen
@@ -97,6 +99,8 @@ namespace NewHorizons.Builder.Props
         public static GameObject Make(GameObject go, Sector sector, IModBehaviour mod, GameObject prefab, DetailInfo detail)
         {
             if (prefab == null) return null;
+
+            if (sector == null) detail.keepLoaded = true;
 
             GameObject prop;
             bool isItem;

--- a/NewHorizons/External/Configs/AddonConfig.cs
+++ b/NewHorizons/External/Configs/AddonConfig.cs
@@ -41,6 +41,7 @@ namespace NewHorizons.External.Configs
         /// <summary>
         /// The path to the addons subtitle for the main menu.
         /// Defaults to "subtitle.png".
+        /// The dimensions of the Echos of the Eye subtitle is 669 x 67, so aim for that size
         /// </summary>
         public string subtitlePath = "subtitle.png";
     }

--- a/NewHorizons/External/Configs/PlanetConfig.cs
+++ b/NewHorizons/External/Configs/PlanetConfig.cs
@@ -281,7 +281,7 @@ namespace NewHorizons.External.Configs
             }
 
             // Stars and focal points shouldnt be destroyed by stars
-            if (Star != null || FocalPoint != null) Base.invulnerableToSun = true;
+            if (Star != null || FocalPoint != null) Base.hasFluidDetector = false;
         }
 
         public void Migrate()
@@ -663,6 +663,11 @@ namespace NewHorizons.External.Configs
                 {
                     if (destructionVolume.onlyAffectsPlayerAndShip) destructionVolume.onlyAffectsPlayerRelatedBodies = true;
                 }
+            }
+
+            if (Base.invulnerableToSun)
+            {
+                Base.hasFluidDetector = false;
             }
         }
         #endregion

--- a/NewHorizons/External/Modules/AtmosphereModule.cs
+++ b/NewHorizons/External/Modules/AtmosphereModule.cs
@@ -107,6 +107,12 @@ namespace NewHorizons.External.Modules
         /// </summary>
         [DefaultValue(300f)] public float maxShockSpeed = 300f;
 
+        /// <summary>
+        /// Will the ship automatically try to orient itself to face upwards while in this volume?
+        /// </summary>
+        [DefaultValue(true)]
+        public bool allowShipAutoroll = true;
+
         [JsonObject]
         public class CloudInfo
         {

--- a/NewHorizons/External/Modules/BaseModule.cs
+++ b/NewHorizons/External/Modules/BaseModule.cs
@@ -37,9 +37,11 @@ namespace NewHorizons.External.Modules
         public float groundSize;
 
         /// <summary>
-        /// Can this planet survive entering a star?
+        /// Is this planet able to detect fluid volumes? Disabling this means that entering a star or lava volume will not destroy this planet
+        /// May have adverse effects if anglerfish are added to this planet, disable this if you want those to work (they have fluid volumes in their mouths)
         /// </summary>
-        public bool invulnerableToSun;
+        [DefaultValue(true)]
+        public bool hasFluidDetector = true;
 
         /// <summary>
         /// Do we show the minimap when walking around this planet?
@@ -83,6 +85,9 @@ namespace NewHorizons.External.Modules
         public bool hideProxy;
 
         #region Obsolete
+
+        [Obsolete("invulnerableToSun is deprecated, please use hasFluidDetector instead")]
+        public bool invulnerableToSun;
 
         [Obsolete("IsSatellite is deprecated, please use ShowMinimap instead")]
         public bool isSatellite;

--- a/NewHorizons/External/Modules/BaseModule.cs
+++ b/NewHorizons/External/Modules/BaseModule.cs
@@ -58,6 +58,8 @@ namespace NewHorizons.External.Modules
 
         /// <summary>
         /// A scale height used for a number of things. Should be the approximate radius of the body.
+        /// 
+        /// Affected settings include: Base sector size, proxy body scaling, surface gravity
         /// </summary>
         public float surfaceSize;
 

--- a/NewHorizons/External/Modules/Props/DetailInfo.cs
+++ b/NewHorizons/External/Modules/Props/DetailInfo.cs
@@ -56,6 +56,7 @@ namespace NewHorizons.External.Modules.Props
         /// <summary>
         /// Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?
         /// Also makes this detail visible on the map.
+        /// Keeping many props loaded is bad for performance so use this only when it's actually relevant
         /// Most logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided.
         /// </summary>
         public bool keepLoaded;

--- a/NewHorizons/External/Modules/VariableSize/WaterModule.cs
+++ b/NewHorizons/External/Modules/VariableSize/WaterModule.cs
@@ -26,5 +26,11 @@ namespace NewHorizons.External.Modules.VariableSize
         /// Tint of the water
         /// </summary>
         public MColor tint;
+
+        /// <summary>
+        /// Will the ship automatically try to orient itself to face upwards while in this volume?
+        /// </summary>
+        [DefaultValue(true)]
+        public bool allowShipAutoroll = true;
     }
 }

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -421,8 +421,8 @@ namespace NewHorizons.Handlers
                     if (defaultPrimaryToSun)
                     {
                         NHLogger.LogError($"Couldn't find {body.Config.Orbit.primaryBody}, defaulting to center of solar system");
-                        // TODO: Make this work in other systems. We tried using Locator.GetCenterOfUniverse before but that doesn't work since its too early now
-                        primaryBody = SearchUtilities.Find("Sun_Body")?.GetComponent<AstroObject>();
+                        // Fix #933 not defaulting primary body
+                        primaryBody = (SearchUtilities.Find("Sun_Body") ?? AstroObjectBuilder.CenterOfUniverse)?.GetComponent<AstroObject>();
                     }
                     else
                     {

--- a/NewHorizons/Handlers/SubtitlesHandler.cs
+++ b/NewHorizons/Handlers/SubtitlesHandler.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Utility;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
@@ -31,6 +32,8 @@ namespace NewHorizons.Handlers
 
         private static List<(IModBehaviour mod, string filePath)> _additionalSubtitles = new();
 
+        private CanvasGroup _titleCanvasGroup;
+
         public static void RegisterAdditionalSubtitle(IModBehaviour mod, string filePath)
         {
             _additionalSubtitles.Add((mod, filePath));
@@ -63,6 +66,8 @@ namespace NewHorizons.Handlers
             image.enabled = false;
             var layout = GetComponent<LayoutElement>();
             layout.minHeight = SUBTITLE_HEIGHT;
+
+            _titleCanvasGroup = SearchUtilities.Find("TitleCanvas").GetComponent<CanvasGroup>();
 
             CheckForEOTE();
 
@@ -133,6 +138,12 @@ namespace NewHorizons.Handlers
 
             // don't fade transition subtitles if there's only one subtitle
             if (possibleSubtitles.Count <= 1)
+            {
+                return;
+            }
+
+            // Fix subtitles start cycling before the main menu is visible #844
+            if (_titleCanvasGroup.alpha < 1)
             {
                 return;
             }

--- a/NewHorizons/Handlers/SubtitlesHandler.cs
+++ b/NewHorizons/Handlers/SubtitlesHandler.cs
@@ -109,7 +109,7 @@ namespace NewHorizons.Handlers
             var tex = ImageUtilities.GetTexture(mod, filepath, false);
             if (tex == null) return;
 
-            var sprite = Sprite.Create(tex, new Rect(0.0f, 0.0f, tex.width, Mathf.Max(SUBTITLE_HEIGHT, tex.height)), new Vector2(0.5f, 0.5f), 100.0f);
+            var sprite = Sprite.Create(tex, new Rect(0.0f, 0.0f, tex.width, tex.height), new Vector2(0.5f, 0.5f), 100.0f);
             AddSubtitle(sprite);
         }
 

--- a/NewHorizons/Schemas/addon_manifest_schema.json
+++ b/NewHorizons/Schemas/addon_manifest_schema.json
@@ -36,7 +36,7 @@
     },
     "subtitlePath": {
       "type": "string",
-      "description": "The path to the addons subtitle for the main menu.\nDefaults to \"subtitle.png\"."
+      "description": "The path to the addons subtitle for the main menu.\nDefaults to \"subtitle.png\".\nThe dimensions of the Echos of the Eye subtitle is 669 x 67, so aim for that size"
     },
     "$schema": {
       "type": "string",

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -568,7 +568,7 @@
         },
         "surfaceSize": {
           "type": "number",
-          "description": "A scale height used for a number of things. Should be the approximate radius of the body.",
+          "description": "A scale height used for a number of things. Should be the approximate radius of the body.\n\nAffected settings include: Base sector size, proxy body scaling, surface gravity",
           "format": "float"
         },
         "gravityVolumePriority": {

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -409,6 +409,11 @@
           "description": "Maximum speed that your ship can go in the atmosphere where flames will appear at their brightest.",
           "format": "float",
           "default": 300.0
+        },
+        "allowShipAutoroll": {
+          "type": "boolean",
+          "description": "Will the ship automatically try to orient itself to face upwards while in this volume?",
+          "default": true
         }
       }
     },
@@ -3907,6 +3912,11 @@
         "tint": {
           "description": "Tint of the water",
           "$ref": "#/definitions/MColor"
+        },
+        "allowShipAutoroll": {
+          "type": "boolean",
+          "description": "Will the ship automatically try to orient itself to face upwards while in this volume?",
+          "default": true
         }
       }
     },

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1368,7 +1368,7 @@
         },
         "keepLoaded": {
           "type": "boolean",
-          "description": "Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?\nAlso makes this detail visible on the map.\nMost logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided."
+          "description": "Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?\nAlso makes this detail visible on the map.\nKeeping many props loaded is bad for performance so use this only when it's actually relevant\nMost logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided."
         },
         "hasPhysics": {
           "type": "boolean",

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -552,9 +552,10 @@
           "description": "Radius of a simple sphere used as the ground for the planet. If you want to use more complex terrain, leave this as\n0.",
           "format": "float"
         },
-        "invulnerableToSun": {
+        "hasFluidDetector": {
           "type": "boolean",
-          "description": "Can this planet survive entering a star?"
+          "description": "Is this planet able to detect fluid volumes? Disabling this means that entering a star or lava volume will not destroy this planet\nMay have adverse effects if anglerfish are added to this planet, disable this if you want those to work (they have fluid volumes in their mouths)",
+          "default": true
         },
         "showMinimap": {
           "type": "boolean",

--- a/NewHorizons/Schemas/shiplog_schema.xsd
+++ b/NewHorizons/Schemas/shiplog_schema.xsd
@@ -81,7 +81,7 @@
             <xs:element name="AltPhotoCondition" type="xs:string" minOccurs="0" maxOccurs="1">
                 <xs:annotation>
                     <xs:documentation>
-                        If this fact is revealed, show the Alt picture
+                        If this fact is revealed, show the Alt picture. Alt photos use the same file name as default but suffixed with "_alt"
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/amazingalek/owml/master/schemas/manifest_schema.json",
   "filename": "NewHorizons.dll",
-  "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
+  "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
   "version": "1.22.7",


### PR DESCRIPTION
- [ ] JOHN document keeploaded as in say what does this do with culling
- [ ] skybox factor for atmosphere probably
- [ ] maybe put multipliers for surface size?? probably not tho

<!-- A new module or something else important -->

## Major features

-

<!-- A new parameter added to a module, or API feature -->

## Minor features

- Added `allowShipAutoroll` to `Water` and `Atmosphere` (fixes #935)
- Replaced `invulnerableToSun` with `hasFluidDetector` and better documented anglerfish making planets go gorp #830

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->

## Improvements

- Allows subtitles of any size now (images get rescaled if need be) (fixes #893)
- Added documentation of naming scheme for alt ship log images (fixes #848)

<!-- Be sure to reference the existing issue if it exists -->

## Bug fixes

- Fix subtitles start cycling before main menu is visible (fixes #844)
- Fix disappearing signalscope UI after warping to new star system (fixes #934)
- Fix null primary body not defaulting to center of universe in other star systems (fixes #933) (probably)
- Fix proxy details requiring "keepLoaded" set to true to work (fixes #940)
- Handle proxy body edge case when all scales = 0 (fixes #941)
