### PR TITLE
Add postfix patch to disable orphaned signalscope reticles (Fixes #925)

### DIFF
--- a/NewHorizons/Patches/SignalPatches/SignalscopeReticleControllerPatches.cs
+++ b/NewHorizons/Patches/SignalPatches/SignalscopeReticleControllerPatches.cs
@@ -1,0 +1,20 @@
+using HarmonyLib;
+
+namespace NewHorizons.Patches.SignalPatches
+{
+    [HarmonyPatch(typeof(SignalscopeReticleController))]
+    public static class SignalScopeReticleControllerPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(SignalscopeReticleController.UpdateBrackets))]
+        public static void SignalscopeReticleController_UpdateBrackets(SignalscopeReticleController __instance)
+        {
+            var listSignals = Locator.GetAudioSignals();
+            for (int i = listSignals.Count; i < __instance._clonedLeftBrackets.Count; i++)
+            {
+                __instance._clonedLeftBrackets[i].enabled = false;
+                __instance._clonedRightBrackets[i].enabled = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug fixes
- "Orphaned" signalscope reticles are disabled instead of being stuck on screen when a signal is disabled (fixes #925 )