### PR TITLE
Multiple spawn points

### DIFF
--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -1,18 +1,17 @@
-using NewHorizons.External.Configs;
-using NewHorizons.Utility;
-using NewHorizons.External.Modules.VariableSize;
-using UnityEngine;
-
-using System.Collections.Generic;
-using NewHorizons.Components.SizeControllers;
-using Color = UnityEngine.Color;
-using NewHorizons.Components.Volumes;
 using NewHorizons.Builder.Props;
-using NewHorizons.Utility.OWML;
-using NewHorizons.Utility.OuterWilds;
-using NewHorizons.External.SerializableData;
 using NewHorizons.Builder.Volumes;
+using NewHorizons.Components.SizeControllers;
+using NewHorizons.Components.Volumes;
+using NewHorizons.External.Configs;
+using NewHorizons.External.Modules.VariableSize;
+using NewHorizons.External.SerializableData;
+using NewHorizons.Utility;
+using NewHorizons.Utility.OuterWilds;
+using NewHorizons.Utility.OWML;
 using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Color = UnityEngine.Color;
 
 namespace NewHorizons.Builder.Body
 {
@@ -88,7 +87,7 @@ namespace NewHorizons.Builder.Body
             Vector3 localRotation = singularity?.rotation == null ? Vector3.zero : singularity.rotation;
 
             GameObject newSingularity = MakeSingularity(go, sector, localPosition, localRotation, polarity, horizonRadius, distortRadius, 
-                hasHazardVolume, singularity.targetStarSystem, singularity.curve, singularity.hasWarpEffects, singularity.renderQueueOverride, singularity.rename, singularity.parentPath, singularity.isRelativeToParent);
+                hasHazardVolume, singularity.targetStarSystem, singularity.spawnPointID, singularity.curve, singularity.hasWarpEffects, singularity.renderQueueOverride, singularity.rename, singularity.parentPath, singularity.isRelativeToParent);
 
             var uniqueID = string.IsNullOrEmpty(singularity.uniqueID) ? config.name : singularity.uniqueID;
             
@@ -161,7 +160,7 @@ namespace NewHorizons.Builder.Body
         }
 
         public static GameObject MakeSingularity(GameObject planetGO, Sector sector, Vector3 position, Vector3 rotation, bool polarity, float horizon, float distort,
-            bool hasDestructionVolume, string targetStarSystem = null, TimeValuePair[] curve = null, bool warpEffects = true, int renderQueue = 2985, string rename = null, string parentPath = null, bool isRelativeToParent = false)
+            bool hasDestructionVolume, string targetStarSystem = null, string targetSpawnID = null, TimeValuePair[] curve = null, bool warpEffects = true, int renderQueue = 2985, string rename = null, string parentPath = null, bool isRelativeToParent = false)
         {
             // polarity true = black, false = white
 
@@ -233,6 +232,7 @@ namespace NewHorizons.Builder.Body
                     {
                         var wormholeVolume = destructionVolumeGO.AddComponent<BlackHoleWarpVolume>();
                         wormholeVolume.TargetSolarSystem = targetStarSystem;
+                        wormholeVolume.TargetSpawnID = targetSpawnID;
                     }
                 }
                 else

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -42,15 +42,21 @@ namespace NewHorizons.Builder.General
                 spawnGO.SetActive(false);
                 spawnGO.layer = Layer.PlayerSafetyCollider;
 
-                ShipSpawn = spawnGO.AddComponent<SpawnPoint>();
-                ShipSpawn._isShipSpawn = true;
-                ShipSpawn._attachedBody = owRigidBody;
-                ShipSpawn._spawnLocation = SpawnLocation.None;
+                var shipSpawn = spawnGO.AddComponent<SpawnPoint>();
+                shipSpawn._isShipSpawn = true;
+                shipSpawn._attachedBody = owRigidBody;
+                shipSpawn._spawnLocation = SpawnLocation.None;
 
                 // #601 we need to actually set the right trigger volumes here
-                ShipSpawn._triggerVolumes = new OWTriggerVolume[0];
+                shipSpawn._triggerVolumes = new OWTriggerVolume[0];
 
-                ShipSpawnOffset = module.shipSpawn.offset ?? (module.shipSpawn.alignRadial.GetValueOrDefault() ? Vector3.up * 4 : Vector3.zero);
+                var shipSpawnOffset = module.shipSpawn.offset ?? (module.shipSpawn.alignRadial.GetValueOrDefault() ? Vector3.up * 4 : Vector3.zero);
+
+                if (ShipSpawn == null || module.shipSpawn.IsDefault())
+                {
+                    ShipSpawn = shipSpawn;
+                    ShipSpawnOffset = shipSpawnOffset;
+                }
 
                 spawnGO.SetActive(true);
             }

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -94,6 +94,7 @@ namespace NewHorizons.Builder.General
                 suitUpQueued = true;
                 Delay.RunWhen(() => Main.IsSystemReady, () =>
                 {
+                    suitUpQueued = false;
                     if (Main.Instance.IsWarpingFromVessel || (!Main.Instance.IsWarpingFromShip && (PlayerSpawnInfo?.startWithSuit ?? false)))
                     {
                         SuitUp();
@@ -108,7 +109,6 @@ namespace NewHorizons.Builder.General
 
         public static void SuitUp()
         {
-            suitUpQueued = false;
             if (!Locator.GetPlayerController()._isWearingSuit)
             {
                 Locator.GetPlayerSuit().SuitUp(false, true, true);

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -13,8 +13,21 @@ namespace NewHorizons.Builder.General
     public static class SpawnPointBuilder
     {
         private static bool suitUpQueued = false;
+
+        // Ship
+        public static SpawnModule.ShipSpawnPoint ShipSpawnInfo { get; private set; }
         public static SpawnPoint ShipSpawn { get; private set; }
         public static Vector3 ShipSpawnOffset { get; private set; }
+
+        // Player
+        public static SpawnModule.PlayerSpawnPoint PlayerSpawnInfo { get; private set; }
+        public static SpawnPoint PlayerSpawn { get; private set; }
+
+        public static void OverridePlayerSpawn(SpawnPoint newSpawn)
+        {
+            PlayerSpawn = newSpawn;
+            PlayerSpawnInfo = null;
+        }
 
         public static SpawnPoint Make(GameObject planetGO, SpawnModule module, OWRigidbody owRigidBody)
         {
@@ -34,6 +47,12 @@ namespace NewHorizons.Builder.General
 
                 // This was a stupid hack to stop players getting stuck in the ground and now we have to keep it forever
                 spawnGO.transform.position += spawnGO.transform.TransformDirection(module.playerSpawn.offset ?? Vector3.up * 4f);
+
+                if (PlayerSpawn == null || module.playerSpawn.GetPriority() > PlayerSpawnInfo.GetPriority())
+                {
+                    PlayerSpawn = playerSpawn;
+                    PlayerSpawnInfo = module.playerSpawn;
+                }
             }
 
             if (module.shipSpawn != null)
@@ -52,10 +71,11 @@ namespace NewHorizons.Builder.General
 
                 var shipSpawnOffset = module.shipSpawn.offset ?? (module.shipSpawn.alignRadial.GetValueOrDefault() ? Vector3.up * 4 : Vector3.zero);
 
-                if (ShipSpawn == null || module.shipSpawn.IsDefault())
+                if (ShipSpawn == null || module.shipSpawn.GetPriority() > ShipSpawnInfo.GetPriority())
                 {
                     ShipSpawn = shipSpawn;
                     ShipSpawnOffset = shipSpawnOffset;
+                    ShipSpawnInfo = module.shipSpawn;
                 }
 
                 spawnGO.SetActive(true);

--- a/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
@@ -11,6 +11,7 @@ namespace NewHorizons.Builder.Volumes
             var volume = VolumeBuilder.Make<WarpVolume>(planetGO, sector, info);
 
             volume.TargetSolarSystem = info.targetStarSystem;
+            volume.TargetSpawnID = info.spawnPointID;
 
             return volume;
         }

--- a/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
+++ b/NewHorizons/Components/ShipLog/ShipLogStarChartMode.cs
@@ -211,7 +211,7 @@ namespace NewHorizons.Components.ShipLog
         {
             if (_starSystemCards.Count == 0)
             {
-                NHLogger.LogWarning("Showing star chart mode when there are no avaialble systems");
+                NHLogger.LogWarning("Showing star chart mode when there are no available systems");
                 return;
             }
 

--- a/NewHorizons/Components/Volumes/BlackHoleWarpVolume.cs
+++ b/NewHorizons/Components/Volumes/BlackHoleWarpVolume.cs
@@ -1,8 +1,11 @@
+using NewHorizons.Handlers;
+
 namespace NewHorizons.Components.Volumes
 {
     public class BlackHoleWarpVolume : BlackHoleDestructionVolume
     {
         public string TargetSolarSystem { get; set; }
+        public string TargetSpawnID { get; set; }
 
         public override void Awake()
         {
@@ -19,6 +22,7 @@ namespace NewHorizons.Components.Volumes
         {
             Locator.GetPlayerAudioController().PlayOneShotInternal(AudioType.BH_BlackHoleEmission);
             Main.Instance.ChangeCurrentStarSystem(TargetSolarSystem, PlayerState.AtFlightConsole());
+            PlayerSpawnHandler.TargetSpawnID = TargetSpawnID;
         }
     }
 }

--- a/NewHorizons/Components/Volumes/WarpVolume.cs
+++ b/NewHorizons/Components/Volumes/WarpVolume.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Handlers;
 using UnityEngine;
 
 namespace NewHorizons.Components.Volumes
@@ -5,6 +6,7 @@ namespace NewHorizons.Components.Volumes
     internal class WarpVolume : BaseVolume
     {
         public string TargetSolarSystem;
+        public string TargetSpawnID;
 
         public override void OnTriggerVolumeEntry(GameObject hitObj)
         {
@@ -13,6 +15,7 @@ namespace NewHorizons.Components.Volumes
                 if (Main.Instance.CurrentStarSystem != TargetSolarSystem) // Otherwise it really breaks idk why
                 {
                     Main.Instance.ChangeCurrentStarSystem(TargetSolarSystem, PlayerState.AtFlightConsole());
+                    PlayerSpawnHandler.TargetSpawnID = TargetSpawnID;
                 }
             }
         }

--- a/NewHorizons/External/Configs/PlanetConfig.cs
+++ b/NewHorizons/External/Configs/PlanetConfig.cs
@@ -1,3 +1,4 @@
+using Epic.OnlineServices;
 using NewHorizons.External.Modules;
 using NewHorizons.External.Modules.Props;
 using NewHorizons.External.Modules.Props.Audio;
@@ -538,6 +539,22 @@ namespace NewHorizons.External.Configs
                     position = Spawn.shipSpawnPoint,
                     rotation = Spawn.shipSpawnRotation,
                 };
+            }
+
+            // Spawn points are now a list
+            if (Spawn != null && Spawn.playerSpawn != null && Spawn.playerSpawnPoints == null)
+            {
+                Spawn.playerSpawnPoints = new SpawnModule.PlayerSpawnPoint[] { Spawn.playerSpawn };
+            }
+            if (Spawn != null && Spawn.shipSpawn != null && Spawn.shipSpawnPoints == null)
+            {
+                Spawn.shipSpawnPoints = new SpawnModule.ShipSpawnPoint[] { Spawn.shipSpawn };
+            }
+
+            // Because these guys put TWO spawn points 
+            if (starSystem == "2walker2.OogaBooga" && name == "The Campground")
+            {
+                Spawn.playerSpawnPoints[0].isDefault = true;
             }
 
             // Remote dialogue trigger reorganized to use GeneralPointPropInfo

--- a/NewHorizons/External/Modules/SpawnModule.cs
+++ b/NewHorizons/External/Modules/SpawnModule.cs
@@ -35,34 +35,41 @@ namespace NewHorizons.External.Modules
             /// <summary>
             /// Whether this planet's spawn point is the one the player/ship will initially spawn at, if multiple spawn points exist.
             /// Do not use at the same time as makeDefaultIfFactRevealed or makeDefaultIfPersistentCondition
+            /// Spawns unlocked with this have lowest priority
             /// </summary>
             public bool isDefault;
 
             /// <summary>
             /// If the given ship log fact is revealed, this spawn point will be used
             /// Do not use at the same time as isDefault or makeDefaultIfPersistentCondition
+            /// Spawns unlocked with this have highest priority
             /// </summary>
             public string makeDefaultIfFactRevealed;
 
             /// <summary>
             /// If the given persistent condition is true, this spawn point will be used
             /// Do not use at the same time as isDefault or makeDefaultIfFactRevealed
+            /// Spawns unlocked with this have second highest priority
             /// </summary>
             public string makeDefaultIfPersistentCondition;
 
-            public bool IsDefault()
+            public int GetPriority()
             {
                 if (!string.IsNullOrEmpty(makeDefaultIfFactRevealed) && ShipLogHandler.KnowsFact(makeDefaultIfFactRevealed))
                 {
-                    return true;
+                    return 2;
                 }
                 if (!string.IsNullOrEmpty(makeDefaultIfPersistentCondition) && PlayerData.GetPersistentCondition(makeDefaultIfPersistentCondition))
                 {
-                    return true;
+                    return 1;
+                }
+                if (isDefault)
+                {
+                    return 0;
                 }
                 else
                 {
-                    return isDefault;
+                    return -1;
                 }
             }
         }

--- a/NewHorizons/External/Modules/SpawnModule.cs
+++ b/NewHorizons/External/Modules/SpawnModule.cs
@@ -1,4 +1,5 @@
 using NewHorizons.External.SerializableData;
+using NewHorizons.Handlers;
 using Newtonsoft.Json;
 using System;
 
@@ -30,6 +31,40 @@ namespace NewHorizons.External.Modules
             /// Offsets the player/ship by this local vector when spawning. Used to prevent spawning in the floor. Optional: defaults to (0, 4, 0).
             /// </summary>
             public MVector3 offset;
+
+            /// <summary>
+            /// Whether this planet's spawn point is the one the player/ship will initially spawn at, if multiple spawn points exist.
+            /// Do not use at the same time as makeDefaultIfFactRevealed or makeDefaultIfPersistentCondition
+            /// </summary>
+            public bool isDefault;
+
+            /// <summary>
+            /// If the given ship log fact is revealed, this spawn point will be used
+            /// Do not use at the same time as isDefault or makeDefaultIfPersistentCondition
+            /// </summary>
+            public string makeDefaultIfFactRevealed;
+
+            /// <summary>
+            /// If the given persistent condition is true, this spawn point will be used
+            /// Do not use at the same time as isDefault or makeDefaultIfFactRevealed
+            /// </summary>
+            public string makeDefaultIfPersistentCondition;
+
+            public bool IsDefault()
+            {
+                if (!string.IsNullOrEmpty(makeDefaultIfFactRevealed) && ShipLogHandler.KnowsFact(makeDefaultIfFactRevealed))
+                {
+                    return true;
+                }
+                if (!string.IsNullOrEmpty(makeDefaultIfPersistentCondition) && PlayerData.GetPersistentCondition(makeDefaultIfPersistentCondition))
+                {
+                    return true;
+                }
+                else
+                {
+                    return isDefault;
+                }
+            }
         }
 
         [JsonObject]
@@ -39,12 +74,6 @@ namespace NewHorizons.External.Modules
             /// If you spawn on a planet with no oxygen, you probably want to set this to true ;;)
             /// </summary>
             public bool startWithSuit;
-            /// <summary>
-            /// Whether this planet's spawn point is the one the player will initially spawn at, if multiple spawn points exist.
-            /// </summary>
-            public bool isDefault;
-
-
         }
 
         [JsonObject]

--- a/NewHorizons/External/Modules/SpawnModule.cs
+++ b/NewHorizons/External/Modules/SpawnModule.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Builder.General;
 using NewHorizons.External.SerializableData;
 using NewHorizons.Handlers;
 using Newtonsoft.Json;
@@ -61,8 +62,17 @@ namespace NewHorizons.External.Modules
             /// </summary>
             public string makeDefaultIfPersistentCondition;
 
+            /// <summary>
+            /// ID used to have a black hole or warp volume bring the player to this spawn specifically
+            /// </summary>
+            public string id;
+
             public int GetPriority()
             {
+                if (!string.IsNullOrEmpty(id) && !string.IsNullOrEmpty(PlayerSpawnHandler.TargetSpawnID) && id == PlayerSpawnHandler.TargetSpawnID)
+                {
+                    return 3;
+                }
                 if (!string.IsNullOrEmpty(makeDefaultIfFactRevealed) && ShipLogHandler.KnowsFact(makeDefaultIfFactRevealed))
                 {
                     return 2;

--- a/NewHorizons/External/Modules/SpawnModule.cs
+++ b/NewHorizons/External/Modules/SpawnModule.cs
@@ -10,12 +10,20 @@ namespace NewHorizons.External.Modules
     {
         /// <summary>
         /// If you want the player to spawn on the new body, set a value for this.
+        /// Different spawns can be unlocked with persistent conditions and facts
         /// </summary>
-        public PlayerSpawnPoint playerSpawn;
+        public PlayerSpawnPoint[] playerSpawnPoints;
 
         /// <summary>
         /// Required for the system to be accessible by warp drive.
+        /// Different spawns can be unlocked with persistent conditions and facts
         /// </summary>
+        public ShipSpawnPoint[] shipSpawnPoints;
+
+        [Obsolete("Use playerSpawnPoints instead")]
+        public PlayerSpawnPoint playerSpawn;
+
+        [Obsolete("Use shipSpawnPoints instead")]
         public ShipSpawnPoint shipSpawn;
 
         [Obsolete("playerSpawnPoint is deprecated. Use playerSpawn.position instead")] public MVector3 playerSpawnPoint;

--- a/NewHorizons/External/Modules/VariableSize/SingularityModule.cs
+++ b/NewHorizons/External/Modules/VariableSize/SingularityModule.cs
@@ -55,6 +55,12 @@ namespace NewHorizons.External.Modules.VariableSize
         public string targetStarSystem;
 
         /// <summary>
+        /// If this is a black hole loading a new star system, set the ID of the spawn point you want to use
+        /// Otherwise, will use the default spawn
+        /// </summary>
+        public string spawnPointID;
+
+        /// <summary>
         /// Type of singularity (white hole or black hole)
         /// </summary>
         public SingularityType type;

--- a/NewHorizons/External/Modules/Volumes/VolumeInfos/ChangeStarSystemVolumeInfo.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumeInfos/ChangeStarSystemVolumeInfo.cs
@@ -10,5 +10,11 @@ namespace NewHorizons.External.Modules.Volumes.VolumeInfos
         /// The star system that entering this volume will send you to.
         /// </summary>
         [DefaultValue("SolarSystem")] public string targetStarSystem;
+
+        /// <summary>
+        /// ID assigned to a spawn point in the other system that the player will be sent to
+        /// Uses the default spawn if not set
+        /// </summary>
+        public string spawnPointID;
     }
 }

--- a/NewHorizons/External/NewHorizonBody.cs
+++ b/NewHorizons/External/NewHorizonBody.cs
@@ -106,12 +106,6 @@ namespace NewHorizons.External
                     }
                 }
             }
-
-            // Because these guys put TWO spawn points 
-            if (Mod.ModHelper.Manifest.UniqueName == "2walker2.Evacuation" && Config.name == "The Campground")
-            {
-                Config.Spawn.playerSpawn.isDefault = true;
-            }
         }
 
         #endregion

--- a/NewHorizons/External/NewHorizonsSystem.cs
+++ b/NewHorizons/External/NewHorizonsSystem.cs
@@ -1,5 +1,4 @@
 using NewHorizons.External.Configs;
-using NewHorizons.External.Modules;
 using OWML.Common;
 using System.Linq;
 
@@ -9,10 +8,9 @@ namespace NewHorizons.External
     {
         public string UniqueID;
         public string RelativePath;
-        public SpawnModule Spawn = null;
-        public SpawnPoint SpawnPoint = null;
         public StarSystemConfig Config;
         public IModBehaviour Mod;
+        public bool HasShipSpawn;
 
         public NewHorizonsSystem(string uniqueID, StarSystemConfig config, string relativePath, IModBehaviour mod)
         {

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -504,7 +504,7 @@ namespace NewHorizons.Handlers
                 var spawnPoint = SpawnPointBuilder.Make(go, body.Config.Spawn, owRigidBody);
                 var isVanillaSystem = body.Config.starSystem == "SolarSystem" || body.Config.starSystem == "EyeOfTheUniverse";
                 var needsSpawnPoint = Main.SystemDict[body.Config.starSystem].SpawnPoint == null || isVanillaSystem;
-                var isDefaultSpawn = body.Config.Spawn.playerSpawn?.isDefault ?? true; // Backwards compat
+                var isDefaultSpawn = body.Config.Spawn.playerSpawn?.IsDefault() ?? true; // Backwards compat
                 if (needsSpawnPoint || isDefaultSpawn)
                 {
                     Main.SystemDict[body.Config.starSystem].SpawnPoint = spawnPoint;

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -502,13 +502,6 @@ namespace NewHorizons.Handlers
             {
                 NHLogger.LogVerbose($"Making spawn point on {body.Config.name}");
                 var spawnPoint = SpawnPointBuilder.Make(go, body.Config.Spawn, owRigidBody);
-                var isVanillaSystem = body.Config.starSystem == "SolarSystem" || body.Config.starSystem == "EyeOfTheUniverse";
-                var needsSpawnPoint = Main.SystemDict[body.Config.starSystem].SpawnPoint == null || isVanillaSystem;
-                var isDefaultSpawn = body.Config.Spawn.playerSpawn?.IsDefault() ?? true; // Backwards compat
-                if (needsSpawnPoint || isDefaultSpawn)
-                {
-                    Main.SystemDict[body.Config.starSystem].SpawnPoint = spawnPoint;
-                }
             }
 
             if (body.Config.Orbit.showOrbitLine && !body.Config.Orbit.isStatic)

--- a/NewHorizons/Handlers/PlayerSpawnHandler.cs
+++ b/NewHorizons/Handlers/PlayerSpawnHandler.cs
@@ -9,6 +9,11 @@ namespace NewHorizons.Handlers
 {
     public static class PlayerSpawnHandler
     {
+        /// <summary>
+        /// Set during the previous loop, force the player to spawn here
+        /// </summary>
+        public static string TargetSpawnID { get; set; }
+
         public static void SetUpPlayerSpawn()
         {
             if (UsingCustomSpawn())
@@ -146,6 +151,9 @@ namespace NewHorizons.Handlers
             FixPlayerVelocity();
 
             InvulnerabilityHandler.MakeInvulnerable(false);
+
+            // Done spawning
+            TargetSpawnID = null;
         }
 
         private static void FixPlayerVelocity(bool recenter = true)

--- a/NewHorizons/Handlers/PlayerSpawnHandler.cs
+++ b/NewHorizons/Handlers/PlayerSpawnHandler.cs
@@ -200,8 +200,8 @@ namespace NewHorizons.Handlers
             return vector;
         }
 
-        public static bool UsingCustomSpawn() => Main.SystemDict[Main.Instance.CurrentStarSystem].SpawnPoint != null;
+        public static bool UsingCustomSpawn() => SpawnPointBuilder.PlayerSpawn != null;
         public static PlayerSpawner GetPlayerSpawner() => GameObject.FindObjectOfType<PlayerSpawner>();
-        public static SpawnPoint GetDefaultSpawn() => Main.SystemDict[Main.Instance.CurrentStarSystem].SpawnPoint ?? GetPlayerSpawner().GetSpawnPoint(SpawnLocation.TimberHearth);
+        public static SpawnPoint GetDefaultSpawn() => SpawnPointBuilder.PlayerSpawn ?? GetPlayerSpawner().GetSpawnPoint(SpawnLocation.TimberHearth);
     }
 }

--- a/NewHorizons/Handlers/ShipLogHandler.cs
+++ b/NewHorizons/Handlers/ShipLogHandler.cs
@@ -114,10 +114,8 @@ namespace NewHorizons.Handlers
 
         public static bool KnowsFact(string fact)
         {
-            // Works normally in the main system, else check save data directly
-            var shipLogManager = Locator.GetShipLogManager();
-            if (Main.Instance.CurrentStarSystem == "SolarSystem" && shipLogManager != null) return shipLogManager.IsFactRevealed(fact);
-            else return PlayerData.GetShipLogFactSave(fact)?.revealOrder > -1;
+            // Use save data directly so stuff works between systems
+            return PlayerData.GetShipLogFactSave(fact)?.revealOrder > -1;
         }
     }
 }

--- a/NewHorizons/Handlers/StarChartHandler.cs
+++ b/NewHorizons/Handlers/StarChartHandler.cs
@@ -156,14 +156,19 @@ namespace NewHorizons.Handlers
                 _canExitViaWarpDrive = true;
                 if (!Main.HasWarpDrive)
                 {
-                    Main.Instance.EnableWarpDrive();
+                    var flagActuallyAddedACard = false;
                     // Add all cards that now work
                     foreach (var starSystem in Main.SystemDict.Keys)
                     {
                         if (CanWarpToSystem(starSystem))
                         {
                             ShipLogStarChartMode.AddSystemCard(starSystem);
+                            flagActuallyAddedACard = true;
                         }
+                    }
+                    if (flagActuallyAddedACard)
+                    {
+                        Main.Instance.EnableWarpDrive();
                     }
                 }
                 else

--- a/NewHorizons/Handlers/StarChartHandler.cs
+++ b/NewHorizons/Handlers/StarChartHandler.cs
@@ -130,7 +130,7 @@ namespace NewHorizons.Handlers
             var canWarpTo = false;
             if (system.Equals("SolarSystem")) canWarpTo = true;
             else if (system.Equals("EyeOfTheUniverse")) canWarpTo = false;
-            else if (config.Spawn?.shipSpawn != null) canWarpTo = true;
+            else if (config.HasShipSpawn) canWarpTo = true;
 
             var canEnterViaWarpDrive = Main.SystemDict[system].Config.canEnterViaWarpDrive || system == "SolarSystem";
 

--- a/NewHorizons/Handlers/VesselWarpHandler.cs
+++ b/NewHorizons/Handlers/VesselWarpHandler.cs
@@ -1,3 +1,4 @@
+using NewHorizons.Builder.General;
 using NewHorizons.Builder.Props;
 using NewHorizons.Components;
 using NewHorizons.Components.EyeOfTheUniverse;
@@ -240,7 +241,7 @@ namespace NewHorizons.Handlers
             VesselSpawnPoint spawnPoint = vesselObject.GetComponentInChildren<VesselSpawnPoint>(true);
             if (ShouldSpawnAtVessel())
             {
-                system.SpawnPoint = spawnPoint;
+                SpawnPointBuilder.OverridePlayerSpawn(spawnPoint);
             }
 
             vesselObject.SetActive(true);

--- a/NewHorizons/INewHorizons.cs
+++ b/NewHorizons/INewHorizons.cs
@@ -214,5 +214,12 @@ namespace NewHorizons
         /// <param name="mod"></param>
         /// <param name="filePath"></param>
         void AddSubtitle(IModBehaviour mod, string filePath);
+
+        /// <summary>
+        /// Whatever system the player is warping to next, they will spawn at the spawn point with this ID
+        /// Gets reset after warping. Is also overriden by entering a system-changing black hole or warp volume by their `spawnPointID`
+        /// </summary>
+        /// <param name="id"></param>
+        void SetNextSpawnID(string id);
     }
 }

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -922,7 +922,7 @@ namespace NewHorizons
             config.Migrate();
 
             // Check if this system can be warped to
-            if (config.Spawn?.shipSpawn != null)
+            if (config.Spawn?.shipSpawnPoints?.Any() ?? false)
             {
                 SystemDict[config.starSystem].HasShipSpawn = true;
             }
@@ -1074,7 +1074,7 @@ namespace NewHorizons
                 {
                     IsWarpingFromVessel = true;
                 }
-                else if (BodyDict.TryGetValue(DefaultSystemOverride, out var bodies) && bodies.Any(x => x.Config?.Spawn?.shipSpawn != null))
+                else if (BodyDict.TryGetValue(DefaultSystemOverride, out var bodies) && bodies.Any(x => x.Config?.Spawn?.shipSpawnPoints?.Any() ?? false))
                 {
                     IsWarpingFromShip = true;
                 }

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -789,9 +789,6 @@ namespace NewHorizons
 
                         if (body != null)
                         {
-                            // Wanna track the spawn point of each system
-                            if (body.Config.Spawn != null) SystemDict[body.Config.starSystem].Spawn = body.Config.Spawn;
-
                             // Add the new planet to the planet dictionary
                             if (!BodyDict.ContainsKey(body.Config.starSystem)) BodyDict[body.Config.starSystem] = new List<NewHorizonsBody>();
                             BodyDict[body.Config.starSystem].Add(body);
@@ -923,6 +920,12 @@ namespace NewHorizons
             // Has to happen after we make sure theres a system config
             config.Validate();
             config.Migrate();
+
+            // Check if this system can be warped to
+            if (config.Spawn?.shipSpawn != null)
+            {
+                SystemDict[config.starSystem].HasShipSpawn = true;
+            }
 
             return new NewHorizonsBody(config, mod, relativePath);
         }

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -342,5 +342,7 @@ namespace NewHorizons
         public string GetTranslationForOtherText(string text) => TranslationHandler.GetTranslation(text, TranslationHandler.TextType.OTHER);
 
         public void AddSubtitle(IModBehaviour mod, string filePath) => SubtitlesHandler.RegisterAdditionalSubtitle(mod, filePath);
+
+        public void SetNextSpawnID(string id) => PlayerSpawnHandler.TargetSpawnID = id;
     }
 }

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Clay, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.22.7",
+  "version": "1.22.8",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Minor features

- The spawn module now has `playerSpawnPoints` and `shipSpawnPoints` allowing you to define multiple possible spawns on one planet.
- Spawn points now have `makeDefaultIfFactRevealed` and `makeDefaultIfPersistentCondition` allowing you to change which spawn the player uses. Priority goes fact -> persistent condition -> default
- Black holes and change star system volumes now have `spawnPointID`. If this is set, entering one of these volumes will send you to the spawn with a matching `id` (fixes #917)

## Bug fixes:
- Fix empty warp drive ship log page appearing
- Use save data directly when checking for facts for ship log warp drive