### PR TITLE
Held item tracking

### DIFF
--- a/NewHorizons/Handlers/HeldItemHandler.cs
+++ b/NewHorizons/Handlers/HeldItemHandler.cs
@@ -19,6 +19,8 @@ public static class HeldItemHandler
     /// </summary>
     private static Dictionary<string, List<string>> _pathOfItemTakenFromSystem = new();
 
+    public static bool WasAWCTakenFromATP => _pathOfItemTakenFromSystem.TryGetValue("SolarSystem", out var list) && list.Contains(ADVANCED_WARP_CORE);
+
     private static GameObject _currentlyHeldItem;
 
     /// <summary>
@@ -42,6 +44,12 @@ public static class HeldItemHandler
         _trackedPaths.Clear();
 
         _currentStarSystem = Main.Instance.CurrentStarSystem;
+
+        // If we took the AWC out of the main system make sure to disable time loop
+        if (_currentStarSystem != "SolarSystem" && WasAWCTakenFromATP)
+        {
+            TimeLoop.SetTimeLoopEnabled(false);
+        }
 
         if (!_isInitialized)
         {
@@ -127,6 +135,7 @@ public static class HeldItemHandler
         {
             foreach (var path in paths)
             {
+                // Have to wait two frames for the sockets to Awake and Start
                 Delay.FireInNUpdates(() =>
                 {
                     try

--- a/NewHorizons/Handlers/HeldItemHandler.cs
+++ b/NewHorizons/Handlers/HeldItemHandler.cs
@@ -1,0 +1,170 @@
+using HarmonyLib;
+using NewHorizons.Builder.Props;
+using NewHorizons.External.Modules.Props;
+using NewHorizons.Utility;
+using NewHorizons.Utility.OWML;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace NewHorizons.Handlers;
+
+[HarmonyPatch]
+public static class HeldItemHandler
+{
+    /// <summary>
+    /// Dictionary of system name to item path
+    /// If we travel to multiple systems within a single loop, this will hold the items we move between systems
+    /// </summary>
+    private static Dictionary<string, string> _pathOfItemTakenFromSystem = new();
+
+    private static GameObject _currentlyHeldItem;
+
+    /// <summary>
+    /// Track the path of any item we ever pick up, in case we take it out of the system
+    /// </summary>
+    private static Dictionary<GameObject, string> _trackedPaths = new();
+
+    private static bool _isInitialized = false;
+    private static bool _isSystemReady = false;
+
+    /// <summary>
+    /// We keep our own reference to this because when Unload gets called it might have already been updated
+    /// </summary>
+    private static string _currentStarSystem;
+
+    [HarmonyPrefix, HarmonyPatch(typeof(ItemTool), nameof(ItemTool.Awake))]
+    private static void Init()
+    {
+        _trackedPaths.Clear();
+
+        _currentStarSystem = Main.Instance.CurrentStarSystem;
+
+        if (!_isInitialized)
+        {
+            _isInitialized = true;
+            Main.Instance.StarSystemChanging += OnStarSystemChanging;
+            Main.Instance.OnStarSystemLoaded.AddListener(OnSystemReady);
+            GlobalMessenger<DeathType>.AddListener("PlayerDeath", OnPlayerDeath);
+        }
+    }
+
+    private static void OnPlayerDeath(DeathType _)
+    {
+        NHLogger.Log("Player died, resetting held items");
+
+        // Destroy everything
+        _pathOfItemTakenFromSystem.Clear();
+        GameObject.Destroy(_currentlyHeldItem);
+    }
+
+    private static GameObject MakePerfectCopy(GameObject go)
+    {
+        //go.SetActive(false);
+
+        var owItem = go.GetComponent<OWItem>();
+
+        var tempParent = new GameObject();
+        tempParent.transform.position = new Vector3(100000, 0, 0);
+        var newObject = DetailBuilder.Make(tempParent, tempParent.AddComponent<Sector>(), null, go, new DetailInfo() { keepLoaded = true });
+        newObject.SetActive(false);
+        newObject.transform.parent = null;
+        newObject.name = go.name;
+
+        var newOWItem = newObject.GetComponent<OWItem>();
+
+        NHLogger.Log($"Cloned {go.name}, original item has component: [{owItem != null}] new item has component: [{newOWItem != null}]");
+
+        return newObject;
+    }
+
+    private static void OnStarSystemChanging()
+    {
+        if (_currentlyHeldItem != null)
+        {
+            // Track it so that when we return to this system we can delete the original
+            if (_trackedPaths.TryGetValue(_currentlyHeldItem, out var path))
+            {
+                _pathOfItemTakenFromSystem[Main.Instance.CurrentStarSystem] = path;
+            }
+
+            NHLogger.Log($"Scene unloaded, preserved inactive held item {_currentlyHeldItem.name}");
+            // For some reason, the original will get destroyed no matter what do we make a copy
+            _currentlyHeldItem = MakePerfectCopy(_currentlyHeldItem).DontDestroyOnLoad();
+        }
+
+        _trackedPaths.Clear();
+        _isSystemReady = false;
+    }
+
+    private static void OnSystemReady(string _)
+    {
+        // If something was taken from this system during this life, remove it
+        if (_pathOfItemTakenFromSystem.TryGetValue(Main.Instance.CurrentStarSystem, out var path))
+        {
+            NHLogger.Log($"Removing item that was taken from this system at {path}");
+            var item = SearchUtilities.Find(path)?.GetComponent<OWItem>();
+            // Make sure to update the socket it might be in so that it works
+            if (item.GetComponentInParent<OWItemSocket>() is OWItemSocket socket)
+            {
+                socket.RemoveFromSocket();
+            }
+            GameObject.Destroy(item.gameObject);
+        }
+
+        // Give whatever item we were previously holding
+        if (_currentlyHeldItem != null)
+        {
+            NHLogger.Log($"Giving player held item {_currentlyHeldItem.name}");
+            // Else its spawning the item inside the player and for that one frame it kills you
+            var newObject = MakePerfectCopy(_currentlyHeldItem);
+
+            // We wait a bit because at some point after not something resets your held item to nothing
+            Delay.FireInNUpdates(() => 
+            {
+                try
+                {
+                    Locator.GetToolModeSwapper().GetItemCarryTool().PickUpItemInstantly(newObject.GetComponent<OWItem>());
+                    // For some reason picking something up messes up the input mode
+                    if (PlayerState.AtFlightConsole())
+                    {
+                        Locator.GetToolModeSwapper().UnequipTool();
+                        Locator.GetToolModeSwapper().OnEnterFlightConsole(Locator.GetShipBody());
+                    }
+                    newObject.SetActive(true);
+                }
+                catch(Exception e)
+                {
+                    NHLogger.LogError($"Failed to take item {newObject.name} to a new system: {e}");
+                    GameObject.Destroy(_currentlyHeldItem);
+                    _currentlyHeldItem = null;
+                }
+
+            }, 5);
+        }
+
+        _isSystemReady = true;
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(ItemTool), nameof(ItemTool.MoveItemToCarrySocket))]
+    private static void HeldItemChanged(ItemTool __instance, OWItem item)
+    {
+        if (!_isSystemReady)
+        {
+            return;
+        }
+
+        if (item != null)
+        {
+            var path = item.transform.GetPath();
+            if (!_trackedPaths.ContainsKey(item.gameObject))
+            {
+                _trackedPaths[item.gameObject] = path;
+            }
+        }
+
+        NHLogger.Log($"Player is now holding {item?.name ?? "nothing"}");
+        _currentlyHeldItem = item?.gameObject;
+    }
+}

--- a/NewHorizons/Handlers/PlayerSpawnHandler.cs
+++ b/NewHorizons/Handlers/PlayerSpawnHandler.cs
@@ -51,11 +51,21 @@ namespace NewHorizons.Handlers
                 Delay.StartCoroutine(SpawnCoroutine(30));
             }
 
-            var cloak = GetDefaultSpawn()?.GetAttachedOWRigidbody()?.GetComponentInChildren<CloakFieldController>();
-            if (cloak != null)
+
+            // It was NREing in here when it was all ?. so explicit null checks
+            var spawn = GetDefaultSpawn();
+            if (spawn != null)
             {
-                // Ensures it has invoked everything and actually placed the player in the cloaking field #671
-                cloak._firstUpdate = true;
+                var attachedOWRigidBody = spawn.GetAttachedOWRigidbody();
+                if (attachedOWRigidBody != null)
+                {
+                    var cloak = attachedOWRigidBody.GetComponentInChildren<CloakFieldController>();
+                    if (cloak != null)
+                    {
+                        // Ensures it has invoked everything and actually placed the player in the cloaking field #671
+                        cloak._firstUpdate = true;
+                    }
+                }
             }
 
             // Spawn ship

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -949,7 +949,6 @@ namespace NewHorizons
         #endregion Load
 
         #region Change star system
-        public Action StarSystemChanging { get; set; }
         public void ChangeCurrentStarSystem(string newStarSystem, bool warp = false, bool vessel = false)
         {
             // If we're just on the title screen set the system for later
@@ -978,8 +977,6 @@ namespace NewHorizons
 
             if (LoadManager.GetCurrentScene() == OWScene.SolarSystem || LoadManager.GetCurrentScene() == OWScene.EyeOfTheUniverse)
             {
-                StarSystemChanging?.Invoke();
-
                 IsWarpingFromShip = warp;
                 IsWarpingFromVessel = vessel;
                 DidWarpFromVessel = false;

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -58,7 +58,7 @@ namespace NewHorizons
 
         public static float SecondsElapsedInLoop = -1;
 
-        public static bool IsSystemReady { get; private set; }
+        public static bool IsSystemReady { get; private set; }    
 
         public string DefaultStarSystem => SystemDict.ContainsKey(DefaultSystemOverride) ? DefaultSystemOverride : _defaultStarSystem;
         public string CurrentStarSystem
@@ -949,6 +949,7 @@ namespace NewHorizons
         #endregion Load
 
         #region Change star system
+        public Action StarSystemChanging { get; set; }
         public void ChangeCurrentStarSystem(string newStarSystem, bool warp = false, bool vessel = false)
         {
             // If we're just on the title screen set the system for later
@@ -977,6 +978,8 @@ namespace NewHorizons
 
             if (LoadManager.GetCurrentScene() == OWScene.SolarSystem || LoadManager.GetCurrentScene() == OWScene.EyeOfTheUniverse)
             {
+                StarSystemChanging?.Invoke();
+
                 IsWarpingFromShip = warp;
                 IsWarpingFromVessel = vessel;
                 DidWarpFromVessel = false;

--- a/NewHorizons/Patches/TimeLoopPatches.cs
+++ b/NewHorizons/Patches/TimeLoopPatches.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using NewHorizons.Handlers;
 
 namespace NewHorizons.Patches
 {
@@ -14,5 +15,16 @@ namespace NewHorizons.Patches
         [HarmonyPatch(typeof(GlobalMusicController), nameof(GlobalMusicController.UpdateEndTimesMusic))]
         [HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Update))]
         public static bool DisableWithoutTimeLoop() => Main.Instance.TimeLoopEnabled;
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(TimeLoop), nameof(TimeLoop.Start))]
+        public static void TimeLoop_Start(TimeLoop __instance)
+        {
+            // If we took the AWC out of the main system make sure to disable time loop
+            if (Main.Instance.CurrentStarSystem != "SolarSystem" && HeldItemHandler.WasAWCTakenFromATP)
+            {
+                TimeLoop.SetTimeLoopEnabled(false);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Improvements
- Preserve held items when warping (closes #192). Note that if you leave an item in another system and warp out, that item will be gone forever from all systems until you start a new loop. Some items (i.e., slide reels) do not work between systems.

## Bug fixes
- Time loop will be disabled in other systems if you removed the AWC and warped while holding it or using the Vessel. Closes #952
