### PR TITLE
1.24.0

### DIFF
--- a/NewHorizons/Components/Props/NHItem.cs
+++ b/NewHorizons/Components/Props/NHItem.cs
@@ -1,12 +1,5 @@
 using NewHorizons.Builder.Props;
 using NewHorizons.Handlers;
-using OWML.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace NewHorizons.Components.Props

--- a/NewHorizons/Components/Props/NHItemSocket.cs
+++ b/NewHorizons/Components/Props/NHItemSocket.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using UnityEngine;
-
 namespace NewHorizons.Components.Props
 {
     public class NHItemSocket : OWItemSocket

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.24.1",
+  "version": "1.24.0",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Major features
- New dream world related prop types: alarm totems, grapple totems, projection totems, portholes/peepholes, and dream candles. Where possible, these have been modified to work with the regular flashlight as well as the artifact for use outside of the dream world. Thank you Hawkbar for these features! 

## Minor features
- Add `colliderRadius` to `itemSocket` so that you can make them actually work