### PR TITLE
1.24.4

### DIFF
--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -51,7 +51,20 @@ namespace NewHorizons.Builder.General
                     // This was a stupid hack to stop players getting stuck in the ground and now we have to keep it forever
                     spawnGO.transform.position += spawnGO.transform.TransformDirection(point.offset ?? Vector3.up * 4f);
 
-                    if (PlayerSpawn == null || point.GetPriority() > PlayerSpawnInfo.GetPriority())
+                    var flagUseTHSpawn = false;
+                    if (Main.Instance.CurrentStarSystem == "SolarSystem")
+                    {
+                        // When in the base solar system, treat the TH spawn point as being isDefault
+                        // If the priority of any new spawn point is less than that, ignore it
+                        // Do take them if they're equal tho
+                        var minPriority = new SpawnModule.PlayerSpawnPoint() { isDefault = true }.GetPriority();
+                        if (point.GetPriority() < minPriority)
+                        {
+                            //flagUseTHSpawn = true;
+                        }
+                    }
+
+                    if (!flagUseTHSpawn && (PlayerSpawn == null || point.GetPriority() > PlayerSpawnInfo.GetPriority()))
                     {
                         PlayerSpawn = playerSpawn;
                         PlayerSpawnInfo = point;

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, Trifid, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes

- TH spawnpoint will not be overridden by custom spawn points unless they are set to be the default. Fixes an unintended issue with the Vision where hearth1an put a non-functioning spawn point inside Ember Twin for no reason that just got activated last update (why hearth1an why).
