### PR TITLE
Shiplog Entry Merging

### DIFF
--- a/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
 using UnityEngine;
+using UnityEngine.InputSystem.HID;
 
 namespace NewHorizons.Builder.ShipLog
 {
@@ -151,6 +152,35 @@ namespace NewHorizons.Builder.ShipLog
                         colAccumulator += step;
                     }
                 }
+            }
+        }
+
+        public static void MergeEntries(ShipLogManager manager, ShipLogEntry entry, ShipLogEntry existing)
+        {
+            foreach (var fact in entry.GetRumorFacts())
+            {
+                existing._rumorFacts.Add(fact);
+                fact.OnFactRevealed += existing.OnFactRevealed;
+
+                manager._factRevealCount = Mathf.Max(manager._factRevealCount, fact.GetRevealOrder());
+                manager._factList.Add(fact);
+                manager._factDict.Add(fact.GetID(), fact);
+            }
+            foreach (var fact in entry.GetExploreFacts())
+            {
+                existing._exploreFacts.Add(fact);
+                existing._completionFacts.Add(fact);
+                fact.OnFactRevealed += existing.OnFactRevealed;
+
+                manager._factRevealCount = Mathf.Max(manager._factRevealCount, fact.GetRevealOrder());
+                manager._factList.Add(fact);
+                manager._factDict.Add(fact.GetID(), fact);
+            }
+            foreach (var child in entry.GetChildren())
+            {
+                existing._childEntries.Add(child);
+
+                manager.AddEntry(child);
             }
         }
 

--- a/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RumorModeBuilder.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
 using UnityEngine;
-using UnityEngine.InputSystem.HID;
 
 namespace NewHorizons.Builder.ShipLog
 {

--- a/NewHorizons/Patches/ShipLogPatches/ShipLogManagerPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogManagerPatches.cs
@@ -129,5 +129,18 @@ namespace NewHorizons.Patches.ShipLogPatches
                 return false;
             }
         }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(ShipLogManager.AddEntry))]
+        public static bool ShipLogManager_AddEntry(ShipLogManager __instance, ShipLogEntry entry)
+        {
+            if (__instance._entryDict.TryGetValue(entry.GetID(), out var existing))
+            {
+                NHLogger.LogVerbose($"Merging duplicate shiplog entry: {entry.GetID()}");
+                RumorModeBuilder.MergeEntries(__instance, entry, existing);
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/docs/src/content/docs/guides/ship-log.md
+++ b/docs/src/content/docs/guides/ship-log.md
@@ -542,3 +542,28 @@ Adding an entry location is similar to adding a Reveal Volume:
 ```
 
 ![entryLocationExample](@/assets/docs-images/ship_log/entry_position.webp)
+
+## Extending Base Game Entries
+
+You can add new facts and sub-entries to existing ship log entries by adding a dummy entry to your ship log XML file with the same ID as an existing entry. Any facts and sub-entries will be applied to the existing entry. For example, to extend the "Village" entry on Timber Hearth (which has the internal ID "TH_VILLAGE"):
+
+```xml title="ExampleShipLog.xml"
+<AstroObjectEntry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/Outer-Wilds-New-Horizons/new-horizons/main/NewHorizons/Schemas/shiplog_schema.xsd">
+    <ID>TIMBER_HEARTH</ID>
+    <Entry>
+        <ID>TH_VILLAGE</ID>
+        <ExploreFact>
+            <ID>EXAMPLES_VILLAGE</ID>
+            <Text>A lot of unfamiliar characters are hanging around the village now.</Text>
+        </ExploreFact>
+        <Entry>
+            <ID>EXAMPLES_DREAM</ID>
+            <Name>Wetrock Dream</Name>
+            <ExploreFact>
+                <ID>EXAMPLES_DREAM_EXPLORED</ID>
+                <Text>I dreamed about Wetrock using a green campfire.</Text>
+            </ExploreFact>
+        </Entry>
+    </Entry>
+</AstroObjectEntry>
+```


### PR DESCRIPTION
## Minor features

- Modded ship log entries with the same ID as an existing entry are now merged into that original entry, allowing for new rumor and explore facts and sub-entries to be added to vanilla ship log entries. Implements #996 