### PR TITLE
Ship Log Take staticPosition into Account

### DIFF
--- a/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
@@ -454,9 +454,9 @@ namespace NewHorizons.Builder.ShipLog
             foreach (NewHorizonsBody body in bodies.Where(b => b.Config.Base.centerOfSolarSystem))
             {
                 bodies.Sort((b, o) => {
-                    var bKey = b.Config.Orbit.isStatic ? b.Config.Orbit.staticPosition.magnitude : b.Config.Orbit.semiMajorAxis;
-                    var oKey = o.Config.Orbit.isStatic ? o.Config.Orbit.staticPosition.magnitude : o.Config.Orbit.semiMajorAxis;
-                    bKey.CompareTo(oKey);
+                    var bKey = b.Config.Orbit.isStatic ? ((Vector3)b.Config.Orbit.staticPosition).magnitude : b.Config.Orbit.semiMajorAxis;
+                    var oKey = o.Config.Orbit.isStatic ? ((Vector3)o.Config.Orbit.staticPosition).magnitude : o.Config.Orbit.semiMajorAxis;
+                    return bKey.CompareTo(oKey);
                 });
                 MapModeObject newNode = new MapModeObject
                 {

--- a/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
@@ -453,7 +453,11 @@ namespace NewHorizons.Builder.ShipLog
 
             foreach (NewHorizonsBody body in bodies.Where(b => b.Config.Base.centerOfSolarSystem))
             {
-                bodies.Sort((b, o) => b.Config.Orbit.semiMajorAxis.CompareTo(o.Config.Orbit.semiMajorAxis));
+                bodies.Sort((b, o) => {
+                    var bKey = b.Config.Orbit.isStatic ? b.Config.Orbit.staticPosition.magnitude : b.Config.Orbit.semiMajorAxis;
+                    var oKey = o.Config.Orbit.isStatic ? o.Config.Orbit.staticPosition.magnitude : o.Config.Orbit.semiMajorAxis;
+                    bKey.CompareTo(oKey);
+                });
                 MapModeObject newNode = new MapModeObject
                 {
                     mainBody = body,


### PR DESCRIPTION
<!-- A new module or something else important -->

## Major features

-

<!-- A new parameter added to a module, or API feature -->

## Minor features

- 

<!-- Some improvement that requires no action on the part of add-on creators i.e., improved star graphics -->

## Improvements

- Automatic Ship Log map mode now takes `staticPosition` into account when determining display order (resolved #1007)

<!-- Be sure to reference the existing issue if it exists -->

## Bug fixes

-
