### PR TITLE
Add selectable to map mode, fix an NRE, make auto map gen lines debug

### DIFF
--- a/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/MapModeBuilder.cs
@@ -21,11 +21,25 @@ namespace NewHorizons.Builder.ShipLog
     {
         // Takes the game object because sometimes we change the AO to an NHAO and it breaks
         private static Dictionary<GameObject, ShipLogAstroObject> _astroObjectToShipLog = new();
+        private static Dictionary<ShipLogAstroObject, MapModeInfo> _astroObjectToMapModeInfo = new();
+
+        public static MapModeInfo GetMapModeInfoForAstroObject(ShipLogAstroObject slao)
+        {
+            if (_astroObjectToMapModeInfo.TryGetValue(slao, out var mapModeInfo))
+            {
+                return mapModeInfo;
+            } 
+            else
+            {
+                return null;
+            }
+        }
 
         #region General
         public static ShipLogAstroObject[][] ConstructMapMode(string systemName, GameObject transformParent, ShipLogAstroObject[][] currentNav, int layer)
         {
             _astroObjectToShipLog = new();
+            _astroObjectToMapModeInfo = new();
 
             // Add stock planets
             foreach (var shipLogAstroObject in currentNav.SelectMany(x => x))
@@ -65,7 +79,7 @@ namespace NewHorizons.Builder.ShipLog
                 else
                 {
                     flagManualPositionUsed = true;
-                    if (body.Config.ShipLog?.mapMode?.manualNavigationPosition == null)
+                    if (body.Config.ShipLog?.mapMode != null && body.Config.ShipLog.mapMode.manualNavigationPosition == null && body.Config.ShipLog.mapMode.selectable)
                     {
                         NHLogger.LogError("Navigation position is missing for: " + body.Config.name);
                         return null;
@@ -172,6 +186,7 @@ namespace NewHorizons.Builder.ShipLog
             ShipLogAstroObject astroObject = gameObject.AddComponent<ShipLogAstroObject>();
             astroObject._id = ShipLogHandler.GetAstroObjectId(body);
             _astroObjectToShipLog[body.Object] = astroObject;
+            _astroObjectToMapModeInfo[astroObject] = body.Config.ShipLog?.mapMode;
 
             Texture2D image = null;
             Texture2D outline = null;
@@ -582,7 +597,10 @@ namespace NewHorizons.Builder.ShipLog
                 astroObject._unviewedObj.GetComponent<Image>().enabled = false;
             }
             node.astroObject = astroObject;
-            if (node.lastSibling != null) ConnectNodeToLastSibling(node, greyScaleMaterial);
+            if (NewHorizons.Main.Debug)
+            {
+                if (node.lastSibling != null) ConnectNodeToLastSibling(node, greyScaleMaterial);
+            }
             MakeDetails(node.mainBody, newNodeGO.transform, greyScaleMaterial);
         }
         #endregion

--- a/NewHorizons/External/Modules/ShipLogModule.cs
+++ b/NewHorizons/External/Modules/ShipLogModule.cs
@@ -79,6 +79,12 @@ namespace NewHorizons.External.Modules
             /// Scale to apply to the planet in map mode.
             /// </summary>
             [DefaultValue(1f)] public float scale = 1f;
+
+            /// <summary>
+            /// Can this ship log map mode entry be selected
+            /// Ex) Set to false for stars with no entries on them so they are skipped in navigation
+            /// </summary>
+            [DefaultValue(true)] public bool selectable = true;
         }
 
         [JsonObject]

--- a/NewHorizons/Patches/ShipLogPatches/ShipLogAstroObjectPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogAstroObjectPatches.cs
@@ -31,7 +31,7 @@ namespace NewHorizons.Patches.ShipLogPatches
         {
             // Custom astro objects might have no entries, in this case they will be permanently hidden
             // Just treat it as if it were revealed
-            if (__instance._entries.Count == 0)
+            if (__instance._entries == null || __instance._entries.Count == 0)
             {
                 __instance._state = ShipLogEntry.State.Explored;
                 __instance._imageObj.SetActive(true);

--- a/NewHorizons/Patches/ShipLogPatches/ShipLogMapModePatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogMapModePatches.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using NewHorizons.Builder.ShipLog;
+using NewHorizons.Components.Orbital;
 using NewHorizons.Handlers;
 using NewHorizons.Utility;
 using NewHorizons.Utility.OWML;
@@ -19,6 +20,29 @@ namespace NewHorizons.Patches.ShipLogPatches
             GameObject panRoot = SearchUtilities.Find(ShipLogHandler.PAN_ROOT_PATH);
             GameObject sunObject = SearchUtilities.Find(ShipLogHandler.PAN_ROOT_PATH + "/Sun");
             ShipLogAstroObject[][] navMatrix = MapModeBuilder.ConstructMapMode(Main.Instance.CurrentStarSystem, panRoot, __instance._astroObjects, sunObject.layer);
+            // Remove anything that isnt meant to be selectable
+            var flagRemovedUnselectable = false;
+            for (int i = 0; i < navMatrix.Length; i++)
+            {
+                for (int j = 0; j < navMatrix[i].Length; j++)
+                {
+                    if (!(MapModeBuilder.GetMapModeInfoForAstroObject(navMatrix[i][j])?.selectable ?? true))
+                    {
+                        flagRemovedUnselectable = true;
+                        navMatrix[i][j].UpdateState();
+                        navMatrix[i][j] = null;
+                    }
+                }
+            }
+            if (flagRemovedUnselectable)
+            {
+                navMatrix = navMatrix.Where(a => a.Count(c => c != null) > 0).ToArray();
+                for (var index = 0; index < navMatrix.Length; index++)
+                {
+                    navMatrix[index] = navMatrix[index].Where(a => a != null).ToArray();
+                }
+            }
+
             if (navMatrix == null || navMatrix.Length <= 1)
             {
                 NHLogger.LogWarning("Skipping Map Mode Generation.");

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -4067,6 +4067,11 @@
           "description": "Scale to apply to the planet in map mode.",
           "format": "float",
           "default": 1.0
+        },
+        "selectable": {
+          "type": "boolean",
+          "description": "Can this ship log map mode entry be selected\nEx) Set to false for stars with no entries on them so they are skipped in navigation",
+          "default": true
         }
       }
     },


### PR DESCRIPTION
## Minor features

- Added `selectable` to map mode info, allowing you to make the map mode icon not able to be selected (useful for bodies without ship logs like stars) Fixes #1003 