### PR TITLE
Fix quantum object socket rotation

### DIFF
--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -12,6 +12,7 @@ using OWML.Common;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using NewHorizons.External.Modules.Props;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Props
@@ -164,13 +165,13 @@ namespace NewHorizons.Builder.Props
 
             if (config.Props.quantumGroups != null)
             {
-                var propsByGroup = new Dictionary<string, List<(GameObject go, bool randomizeYRotation)>>();
+                var propsByGroup = new Dictionary<string, List<(GameObject go, DetailInfo detail)>>();
                 foreach (var detail in config.Props.details)
                 {
                     if (detail.quantumGroupID != null)
                     {
-                        if (!propsByGroup.ContainsKey(detail.quantumGroupID)) propsByGroup[detail.quantumGroupID] = new List<(GameObject go, bool randomizeYRotation)>();
-                        propsByGroup[detail.quantumGroupID].Add((DetailBuilder.GetSpawnedGameObjectByDetailInfo(detail), detail.quantumRandomizeYRotation));
+                        if (!propsByGroup.ContainsKey(detail.quantumGroupID)) propsByGroup[detail.quantumGroupID] = new List<(GameObject go, DetailInfo detail)>();
+                        propsByGroup[detail.quantumGroupID].Add((DetailBuilder.GetSpawnedGameObjectByDetailInfo(detail), detail));
                     }
                 }
 

--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -164,13 +164,13 @@ namespace NewHorizons.Builder.Props
 
             if (config.Props.quantumGroups != null)
             {
-                Dictionary<string, List<GameObject>> propsByGroup = new Dictionary<string, List<GameObject>>();
+                var propsByGroup = new Dictionary<string, List<(GameObject go, bool randomizeYRotation)>>();
                 foreach (var detail in config.Props.details)
                 {
                     if (detail.quantumGroupID != null)
                     {
-                        if (!propsByGroup.ContainsKey(detail.quantumGroupID)) propsByGroup[detail.quantumGroupID] = new List<GameObject>();
-                        propsByGroup[detail.quantumGroupID].Add(DetailBuilder.GetSpawnedGameObjectByDetailInfo(detail));
+                        if (!propsByGroup.ContainsKey(detail.quantumGroupID)) propsByGroup[detail.quantumGroupID] = new List<(GameObject go, bool randomizeYRotation)>();
+                        propsByGroup[detail.quantumGroupID].Add((DetailBuilder.GetSpawnedGameObjectByDetailInfo(detail), detail.quantumRandomizeYRotation));
                     }
                 }
 

--- a/NewHorizons/Builder/Props/QuantumBuilder.cs
+++ b/NewHorizons/Builder/Props/QuantumBuilder.cs
@@ -6,6 +6,7 @@ using NewHorizons.Utility.OWML;
 using OWML.Common;
 using System.Collections.Generic;
 using System.Linq;
+using NewHorizons.External.Modules.Props;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Props
@@ -13,7 +14,7 @@ namespace NewHorizons.Builder.Props
     public static class QuantumBuilder
     {
 
-        public static void Make(GameObject go, Sector sector, PlanetConfig config, IModBehaviour mod, QuantumGroupInfo quantumGroup, (GameObject go, bool randomizeY)[] propsInGroup)
+        public static void Make(GameObject go, Sector sector, PlanetConfig config, IModBehaviour mod, QuantumGroupInfo quantumGroup, (GameObject go, DetailInfo detail)[] propsInGroup)
         {
             switch (quantumGroup.type)
             {
@@ -25,14 +26,12 @@ namespace NewHorizons.Builder.Props
 
         // TODO: Socket groups that have an equal number of props and sockets
         // Nice to have: socket groups that specify a filledSocketObject and an emptySocketObject (eg the archway in the giant's deep tower)
-        public static void MakeSocketGroup(GameObject go, Sector sector, PlanetConfig config, IModBehaviour mod, QuantumGroupInfo quantumGroup, (GameObject go, bool randomizeY)[] propsInGroup)
+        public static void MakeSocketGroup(GameObject go, Sector sector, PlanetConfig config, IModBehaviour mod, QuantumGroupInfo quantumGroup, (GameObject go, DetailInfo detail)[] propsInGroup)
         {
             var groupRoot = new GameObject("Quantum Sockets - " + quantumGroup.id);
             groupRoot.transform.parent = sector?.transform ?? go.transform;
             groupRoot.transform.localPosition = Vector3.zero;
             groupRoot.transform.localEulerAngles = Vector3.zero;
-
-            var useSocketRotation = quantumGroup.sockets.All(x => x.rotation != null);
 
             var sockets = new QuantumSocket[quantumGroup.sockets.Length];
             for (int i = 0; i < quantumGroup.sockets.Length; i++)
@@ -54,9 +53,9 @@ namespace NewHorizons.Builder.Props
                 quantumObject._socketList = sockets.ToList();
                 quantumObject._sockets = sockets;
                 quantumObject._prebuilt = true;
-                quantumObject._alignWithSocket = useSocketRotation;
-                quantumObject._randomYRotation = prop.randomizeY;
-                quantumObject._alignWithGravity = !useSocketRotation;
+                quantumObject._alignWithSocket = !prop.detail.quantumAlignWithGravity;
+                quantumObject._randomYRotation = prop.detail.quantumRandomizeYRotation;
+                quantumObject._alignWithGravity = prop.detail.quantumAlignWithGravity;
                 quantumObject._childSockets = new List<QuantumSocket>();
                 if (prop.go.GetComponentInChildren<VisibilityTracker>() == null) AddBoundsVisibility(prop.go);
                 prop.go.SetActive(true);

--- a/NewHorizons/External/Modules/Props/DetailInfo.cs
+++ b/NewHorizons/External/Modules/Props/DetailInfo.cs
@@ -56,7 +56,7 @@ namespace NewHorizons.External.Modules.Props
         /// <summary>
         /// If this prop is quantum, and the quantum group is socketed, this field determines whether the prop will randomly choose a Y rotation when moving to a socket.
         /// </summary>
-        public bool quantumRandomizeYRotation = true;
+        [DefaultValue(true)] public bool quantumRandomizeYRotation = true;
 
         /// <summary>
         /// Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?

--- a/NewHorizons/External/Modules/Props/DetailInfo.cs
+++ b/NewHorizons/External/Modules/Props/DetailInfo.cs
@@ -54,6 +54,11 @@ namespace NewHorizons.External.Modules.Props
         public string quantumGroupID;
 
         /// <summary>
+        /// If this prop is quantum, and the quantum group is socketed, this field determines whether the prop will randomly choose a Y rotation when moving to a socket.
+        /// </summary>
+        public bool quantumRandomizeYRotation = true;
+
+        /// <summary>
         /// Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?
         /// Also makes this detail visible on the map.
         /// Keeping many props loaded is bad for performance so use this only when it's actually relevant

--- a/NewHorizons/External/Modules/Props/DetailInfo.cs
+++ b/NewHorizons/External/Modules/Props/DetailInfo.cs
@@ -59,6 +59,11 @@ namespace NewHorizons.External.Modules.Props
         [DefaultValue(true)] public bool quantumRandomizeYRotation = true;
 
         /// <summary>
+        /// If this prop is quantum, and the quantum group is socketed, this field determines whether the prop will align with the GravityVolume (true) or align with the current socket (false).
+        /// </summary>
+        [DefaultValue(true)] public bool quantumAlignWithGravity = true;
+
+        /// <summary>
         /// Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?
         /// Also makes this detail visible on the map.
         /// Keeping many props loaded is bad for performance so use this only when it's actually relevant

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1466,6 +1466,11 @@
           "description": "If this prop is quantum, and the quantum group is socketed, this field determines whether the prop will randomly choose a Y rotation when moving to a socket.",
           "default": true
         },
+        "quantumAlignWithGravity": {
+          "type": "boolean",
+          "description": "If this prop is quantum, and the quantum group is socketed, this field determines whether the prop will align with the GravityVolume (true) or align with the current socket (false).",
+          "default": true
+        },
         "keepLoaded": {
           "type": "boolean",
           "description": "Should this detail stay loaded (visible and collideable) even if you're outside the sector (good for very large props)?\nAlso makes this detail visible on the map.\nKeeping many props loaded is bad for performance so use this only when it's actually relevant\nMost logic/behavior scripts will still only work inside the sector, as most of those scripts break if a sector is not provided."


### PR DESCRIPTION
Uses socket rotation if non-null, added fields to props to choose whether to randomize Y rotation and whether to align with gravity.

Fixed #751 