### PR TITLE
1.26.0

### DIFF
--- a/NewHorizons/Patches/PlayerImpactAudioPatches.cs
+++ b/NewHorizons/Patches/PlayerImpactAudioPatches.cs
@@ -1,10 +1,5 @@
 using HarmonyLib;
 using NewHorizons.Handlers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace NewHorizons.Patches;
 


### PR DESCRIPTION
## Major features

- Added a new `EyeOfTheUniverse` module to the planet body config for features specific to the Eye of the Universe scene.
- Added `eyeTravelers`, `quantumInstruments`, and `instrumentZones` to the `EyeOfTheUniverse` module to support adding new travelers and instrument 'puzzles' to the Eye of the Universe in a compatibility-minded way. (Thanks Hawkbar!)

## Improvements

- Added Portuguese (Brazil) localization (thank you avengerx and loco-choco!)
- When custom travelers are present, a new custom audio scheduler is used for the campfire song at the Eye of the Universe to reduce desyncing and remove the awkward cross-fade into the finale audio clip.

## Bug fixes

- Fixed raft docks not working with NH rafts (Fixes #1005)
- Fixed a bug caused by fixing focalpoints that broke circumbinary planets
- Stopped orbit lines from generating at the eye (thanks anon!)
- Fixed getting violently flung into a wall and dying when using vessel warp sometimes (Fixes #1034)
- Might have fixed getting violently flung into a wall and dying when using ship warp sometimes (Fixes #975 maybe)