### PR TITLE
Slide reel streaming

### DIFF
--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -375,6 +375,7 @@ namespace NewHorizons.Builder.Props
             }
 
             slideCollectionContainer.slideCollection = slideCollection;
+            slideCollectionContainer._playWithShipLogFacts = Array.Empty<string>();
 
             StreamingHandler.SetUpStreaming(projectorObj, sector);
 

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -507,6 +507,16 @@ namespace NewHorizons.Builder.Props
             return standingTorch;
         }
 
+        /// <summary>
+        /// start loading all the slide stuff we need async.
+        /// </summary>
+        /// <param name="mod">the mod to load slides from</param>
+        /// <param name="slides">slides to load</param>
+        /// <param name="slideCollection">where to assign the slide objects</param>
+        /// <param name="useInvertedCache">should we load cached inverted images?</param>
+        /// <param name="useAtlasCache">should we load cached atlas images?</param>
+        /// <param name="loadRawImages">should we load the original images? happens anyway if cache doesnt exist since atlas or inverted will need it</param>
+        /// <returns>the 3 loaders (inverted, atlas, original). inverted and atlas will be null if cache doesnt exist, so check those to find out if cache exists</returns>
         private static (SlideReelAsyncImageLoader inverted, SlideReelAsyncImageLoader atlas, SlideReelAsyncImageLoader slides)
             StartAsyncLoader(IModBehaviour mod, SlideInfo[] slides, ref SlideCollection slideCollection, bool useInvertedCache, bool useAtlasCache, bool loadRawImages)
         {

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -140,8 +140,6 @@ namespace NewHorizons.Builder.Props
 
             var toDestroy = slideReelObj.GetComponent<SlideCollectionContainer>();
             var slideCollectionContainer = slideReelObj.AddComponent<NHSlideCollectionContainer>();
-            slideCollectionContainer.slidePaths = info.slides.Select(x => x.imagePath).ToArray();
-            slideCollectionContainer.mod = mod;
             slideReel._slideCollectionContainer = slideCollectionContainer;
             Component.DestroyImmediate(toDestroy);
 
@@ -152,7 +150,7 @@ namespace NewHorizons.Builder.Props
 
             // Now we replace the slides
             int slidesCount = info.slides.Length;
-            var slideCollection = new SlideCollection(slidesCount);
+            SlideCollection slideCollection = new NHSlideCollection(slidesCount, mod, info.slides.Select(x => x.imagePath).ToArray());
             slideCollection.streamingAssetIdentifier = string.Empty; // NREs if null
 
             // We can fit 16 slides max into an atlas

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -164,7 +164,7 @@ namespace NewHorizons.Builder.Props
 
             var key = GetUniqueSlideReelID(mod, info.slides);
 
-            if (CacheExists(mod) && atlasImageLoader != null)
+            if (atlasImageLoader != null)
             {
                 atlasImageLoader.imageLoadedEvent.AddListener(
                     (Texture2D tex, int _, string originalPath) =>
@@ -585,7 +585,6 @@ namespace NewHorizons.Builder.Props
                 {
                     atlasImageLoader.Start(false, false);
                 }
-                // When using the inverted cache we never need the regular images
                 if (useInvertedCache)
                 {
                     invertedImageLoader.Start(true, false);

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -554,7 +554,7 @@ namespace NewHorizons.Builder.Props
                         // Load the inverted images used when displaying slide reels to a screen
                         invertedImageLoader.PathsToLoad.Add((i, Path.Combine(mod.ModHelper.Manifest.ModFolderPath, InvertedSlideReelCacheFolder, slideInfo.imagePath)));
                     }
-                    if (loadRawImages)
+                    if (!cacheExists || loadRawImages)
                     {
                         imageLoader.PathsToLoad.Add((i, Path.Combine(mod.ModHelper.Manifest.ModFolderPath, slideInfo.imagePath)));
                     }

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -342,6 +342,7 @@ namespace NewHorizons.Builder.Props
 
             var toDestroy = autoProjector.GetComponent<SlideCollectionContainer>();
             var slideCollectionContainer = autoProjector.gameObject.AddComponent<NHSlideCollectionContainer>();
+            slideCollectionContainer.doAsyncLoading = false;
             autoProjector._slideCollectionItem = slideCollectionContainer;
             Component.DestroyImmediate(toDestroy);
 

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -375,7 +375,7 @@ namespace NewHorizons.Builder.Props
             }
 
             slideCollectionContainer.slideCollection = slideCollection;
-            slideCollectionContainer._playWithShipLogFacts = Array.Empty<string>();
+            slideCollectionContainer._playWithShipLogFacts = Array.Empty<string>(); // else it NREs in container initialize
 
             StreamingHandler.SetUpStreaming(projectorObj, sector);
 

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -209,8 +209,14 @@ namespace NewHorizons.Builder.Props
                             var slidesBack = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Back").GetComponent<MeshRenderer>();
                             var slidesFront = slideReelObj.GetComponentInChildren<TransformAnimator>(true).transform.Find("Slides_Front").GetComponent<MeshRenderer>();
 
-                            // Now put together the textures into a 4x4 thing for the materials
-                            var reelTexture = ImageUtilities.MakeReelTexture(mod, textures, key);
+                            // Now put together the textures into a 4x4 thing for the materials #888
+                            var displayTextures = textures;
+                            if (info.displaySlides != null && info.displaySlides.Length > 0)
+                            {
+                                displayTextures = info.displaySlides.Select(x => textures[x]).ToArray();
+                            }
+
+                            var reelTexture = ImageUtilities.MakeReelTexture(mod, displayTextures, key);
                             slidesBack.material.mainTexture = reelTexture;
                             slidesBack.material.SetTexture(EmissionMap, reelTexture);
                             slidesBack.material.name = reelTexture.name;

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -196,6 +196,7 @@ namespace NewHorizons.Builder.Props
                 {
                     var time = DateTime.Now;
 
+                    // inverted slides will be loaded for the whole loop but its fine since this is only when generating cache
                     slideCollection.slides[index]._image = ImageUtilities.InvertSlideReel(mod, tex, originalPath);
                     NHLogger.LogVerbose($"Slide reel make reel invert texture {(DateTime.Now - time).TotalMilliseconds}ms");
                     // Track the first 16 to put on the slide reel object

--- a/NewHorizons/Components/EOTE/NHSlideCollection.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollection.cs
@@ -27,7 +27,19 @@ public class NHSlideCollection : SlideCollection
 
     static NHSlideCollection()
     {
-        SceneManager.sceneUnloaded += (_) => _slidesRequiringPath.Clear();
+        SceneManager.sceneUnloaded += (_) =>
+        {
+            foreach (var (slide, collections) in _slidesRequiringPath)
+            {
+                // If it has null, that means some other permanent thing loaded this texture and it will get cleared elsewhere
+                // Otherwise it was loaded by an NHSlideCollection and should be deleted
+                if (collections.Any() && !collections.Contains(null))
+                {
+                    ImageUtilities.DeleteTexture(slide);
+                }
+            }
+            _slidesRequiringPath.Clear();
+        };
     }
 
     public NHSlideCollection(int startArrSize, IModBehaviour mod, string[] slidePaths) : base(startArrSize)

--- a/NewHorizons/Components/EOTE/NHSlideCollection.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollection.cs
@@ -1,0 +1,70 @@
+using HarmonyLib;
+using NewHorizons.Utility.Files;
+using OWML.Common;
+using UnityEngine;
+
+namespace NewHorizons.Components.EOTE;
+
+[HarmonyPatch]
+public class NHSlideCollection : SlideCollection
+{
+    
+    public string[] slidePaths;
+    public IModBehaviour mod;
+
+    public NHSlideCollection(int startArrSize, IModBehaviour mod, string[] slidePaths) : base(startArrSize)
+    {
+        this.mod = mod;
+        this.slidePaths = slidePaths;
+    }
+
+    /*
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollection), nameof(SlideCollection.RequestStreamSlides))]
+    public static bool SlideCollection_RequestStreamSlides(SlideCollection __instance, int[] slideIndices)
+    {
+        if (__instance is NHSlideCollection collection)
+        {
+            foreach (var id in slideIndices)
+            {
+                collection.slides[id]._image = ImageUtilities.GetTexture(collection.mod, collection.slidePaths[id]);
+            }
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollection), nameof(SlideCollection.IsStreamedTextureIndexLoaded))]
+    public static bool SlideCollection_IsStreamedTextureIndexLoaded(SlideCollection __instance, int streamIdx, ref bool __result)
+    {
+        if (__instance is NHSlideCollection collection)
+        {
+            __result = ImageUtilities.IsTextureLoaded(collection.mod, collection.slidePaths[streamIdx]);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollection), nameof(SlideCollection.GetStreamingTexture))]
+    public static bool SlideCollection_GetStreamingTexture(SlideCollection __instance, int id, ref Texture __result)
+    {
+        if (__instance is NHSlideCollection collection)
+        {
+            __result = ImageUtilities.GetTexture(collection.mod, collection.slidePaths[id]);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+    */
+}

--- a/NewHorizons/Components/EOTE/NHSlideCollection.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollection.cs
@@ -158,6 +158,7 @@ public class NHSlideCollection : SlideCollection
                     _pathsBeingLoaded.Remove(path);
                     if (_shipLogSlideProjector == null)
                     {
+                        // Object.FindObjectOfType doesnt work with inactive
                         _shipLogSlideProjector = Resources.FindObjectsOfTypeAll<ShipLogSlideProjector>().FirstOrDefault();
                     }
                     if (_shipLogSlideProjector != null)

--- a/NewHorizons/Components/EOTE/NHSlideCollection.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollection.cs
@@ -158,7 +158,7 @@ public class NHSlideCollection : SlideCollection
                     _pathsBeingLoaded.Remove(path);
                     if (_shipLogSlideProjector == null)
                     {
-                        _shipLogSlideProjector = GameObject.FindObjectOfType<ShipLogSlideProjector>();
+                        _shipLogSlideProjector = Resources.FindObjectsOfTypeAll<ShipLogSlideProjector>().FirstOrDefault();
                     }
                     if (_shipLogSlideProjector != null)
                     {

--- a/NewHorizons/Components/EOTE/NHSlideCollection.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollection.cs
@@ -154,7 +154,6 @@ public class NHSlideCollection : SlideCollection
                 loader.imageLoadedEvent.AddListener((Texture2D tex, int index, string originalPath) =>
                 {
                     // weird: sometimes we set image, sometimes we return from GetStreamingTexture. oh well
-                    // also somehow setting this later works and updates the cookie without having to manually tell it to do that??? idk how
                     slides[wrappedIndex]._image = tex;
                     _pathsBeingLoaded.Remove(path);
                     if (_shipLogSlideProjector == null)

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -1,4 +1,12 @@
 using HarmonyLib;
+using NewHorizons.Builder.Props;
+using NewHorizons.External.Modules.Props.EchoesOfTheEye;
+using NewHorizons.Utility.Files;
+using OWML.Common;
+using System;
+using System.IO;
+using System.Linq;
+using UnityEngine;
 
 namespace NewHorizons.Components.EOTE;
 
@@ -7,12 +15,14 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
 {
     public string[] conditionsToSet;
     public string[] persistentConditionsToSet;
+    public string[] slidePaths;
+    public IModBehaviour mod;
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.Initialize))]
     public static bool SlideCollectionContainer_Initialize(SlideCollectionContainer __instance)
     {
-        if (__instance is NHSlideCollectionContainer)
+        if (__instance is NHSlideCollectionContainer container)
         {
             if (__instance._initialized)
                 return false;
@@ -24,7 +34,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
             __instance._changeSlidesAllowed = true;
             __instance._initialized = true;
             __instance._slideCollection.isVision = __instance._owningItem == null;
-            foreach (var factID in __instance._playWithShipLogFacts)
+            foreach (var factID in __instance._playWithShipLogFacts ?? Array.Empty<string>())
             {
                 var fact = Locator.GetShipLogManager().GetFact(factID);
                 fact?.RegisterSlideCollection(__instance._slideCollection);
@@ -57,6 +67,137 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
                     }
                 }
             }
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.NextSlideAvailable))]
+    public static bool SlideCollectionContainer_NextSlideAvailable(SlideCollectionContainer __instance, ref bool __result)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            __result = container.IsSlideLoaded(container.slideIndex + 1);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.PrevSlideAvailable))]
+    public static bool SlideCollectionContainer_PrevSlideAvailable(SlideCollectionContainer __instance, ref bool __result)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            __result = container.IsSlideLoaded(container.slideIndex - 1);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.UnloadStreamingTextures))]
+    public static bool SlideCollectionContainer_UnloadStreamingTextures(SlideCollectionContainer __instance)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            for (int i = 0; i < container.slidePaths.Length; i++)
+            {
+                container.UnloadSlide(i);
+            }
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.GetStreamingTexture))]
+    public static bool SlideCollectionContainer_GetStreamingTexture(SlideCollectionContainer __instance, int id, ref Texture __result)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            __result = container.LoadSlide(id);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.RequestManualStreamSlides))]
+    public static bool SlideCollectionContainer_RequestManualStreamSlides(SlideCollectionContainer __instance)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            container.LoadSlide(__instance._currentSlideIndex);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.streamingTexturesAvailable), MethodType.Getter)]
+    public static bool SlideCollectionContainer_streamingTexturesAvailable(SlideCollectionContainer __instance, ref bool __result)
+    {
+        if (__instance is NHSlideCollectionContainer container)
+        {
+            __result = container.slidePaths != null && container.slidePaths.Any();
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+
+    public Texture LoadSlide(int index)
+    {
+        Texture LoadSlideInt(int index)
+        {
+            var wrappedIndex = (index + this.slideCollection.slides.Length) % this.slideCollection.slides.Length;
+            var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, ProjectionBuilder.InvertedSlideReelCacheFolder, slidePaths[wrappedIndex]);
+
+            var texture = ImageUtilities.GetTexture(mod, path);
+            this.slideCollection.slides[wrappedIndex]._image = texture;
+            return texture;
+        }
+        var texture = LoadSlideInt(index);
+        LoadSlideInt(index - 1);
+        LoadSlideInt(index + 1);
+
+        return texture;
+    }
+
+    public bool IsSlideLoaded(int index)
+    {
+        var wrappedIndex = (index + this.slideCollection.slides.Length) % this.slideCollection.slides.Length;
+        var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, ProjectionBuilder.InvertedSlideReelCacheFolder, slidePaths[wrappedIndex]);
+        return ImageUtilities.IsTextureLoaded(mod, path);
+    }
+
+    public void UnloadSlide(int index)
+    {
+        var wrappedIndex = (index + this.slideCollection.slides.Length) % this.slideCollection.slides.Length;
+        var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, ProjectionBuilder.InvertedSlideReelCacheFolder, slidePaths[wrappedIndex]);
+
+        if (ImageUtilities.IsTextureLoaded(mod, path))
+        {
+            ImageUtilities.DeleteTexture(mod, path, ImageUtilities.GetTexture(mod, path));
+            slideCollection.slides[wrappedIndex]._image = null;
         }
     }
 }

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -27,7 +27,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
             __instance._changeSlidesAllowed = true;
             __instance._initialized = true;
             __instance._slideCollection.isVision = __instance._owningItem == null;
-            foreach (var factID in __instance._playWithShipLogFacts ?? Array.Empty<string>())
+            foreach (var factID in __instance._playWithShipLogFacts)
             {
                 var fact = Locator.GetShipLogManager().GetFact(factID);
                 fact?.RegisterSlideCollection(__instance._slideCollection);

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -31,6 +31,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
             {
                 var fact = Locator.GetShipLogManager().GetFact(factID);
                 fact?.RegisterSlideCollection(__instance._slideCollection);
+                // in original it logs. we dont want that here ig
             }
             return false;
         }

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -10,6 +10,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
 {
     public string[] conditionsToSet;
     public string[] persistentConditionsToSet;
+    // at some point we'll do streaming on all slides. until then just have an off switch
     public bool doAsyncLoading = true;
 
     [HarmonyPrefix]

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -71,7 +71,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            __result = (container.slideCollection as NHSlideCollection).IsSlideLoaded(container.slideIndex + 1);
+            __result = ((NHSlideCollection)container.slideCollection).IsSlideLoaded(container.slideIndex + 1);
             return false;
         }
         else
@@ -87,7 +87,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            __result = (container.slideCollection as NHSlideCollection).IsSlideLoaded(container.slideIndex - 1);
+            __result = ((NHSlideCollection)container.slideCollection).IsSlideLoaded(container.slideIndex - 1);
             return false;
         }
         else
@@ -102,9 +102,9 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            for (int i = 0; i < (container.slideCollection as NHSlideCollection).slidePaths.Length; i++)
+            for (int i = 0; i < ((NHSlideCollection)container.slideCollection).slidePaths.Length; i++)
             {
-                (container.slideCollection as NHSlideCollection).UnloadSlide(i);
+                ((NHSlideCollection)container.slideCollection).UnloadSlide(i);
             }
             return false;
         }
@@ -120,7 +120,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            __result = (container.slideCollection as NHSlideCollection).LoadSlide(id);
+            __result = ((NHSlideCollection)container.slideCollection).LoadSlide(id);
             return false;
         }
         else
@@ -135,7 +135,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            (container.slideCollection as NHSlideCollection).LoadSlide(__instance._currentSlideIndex);
+            ((NHSlideCollection)container.slideCollection).LoadSlide(__instance._currentSlideIndex);
             return false;
         }
         else
@@ -150,7 +150,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     {
         if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
-            __result = (container.slideCollection as NHSlideCollection).slidePaths != null && (container.slideCollection as NHSlideCollection).slidePaths.Any();
+            __result = ((NHSlideCollection)container.slideCollection).slidePaths != null && ((NHSlideCollection)container.slideCollection).slidePaths.Any();
             return false;
         }
         else

--- a/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
+++ b/NewHorizons/Components/EOTE/NHSlideCollectionContainer.cs
@@ -10,6 +10,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
 {
     public string[] conditionsToSet;
     public string[] persistentConditionsToSet;
+    public bool doAsyncLoading = true;
 
     [HarmonyPrefix]
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.Initialize))]
@@ -68,7 +69,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.NextSlideAvailable))]
     public static bool SlideCollectionContainer_NextSlideAvailable(SlideCollectionContainer __instance, ref bool __result)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             __result = (container.slideCollection as NHSlideCollection).IsSlideLoaded(container.slideIndex + 1);
             return false;
@@ -84,7 +85,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.PrevSlideAvailable))]
     public static bool SlideCollectionContainer_PrevSlideAvailable(SlideCollectionContainer __instance, ref bool __result)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             __result = (container.slideCollection as NHSlideCollection).IsSlideLoaded(container.slideIndex - 1);
             return false;
@@ -99,7 +100,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.UnloadStreamingTextures))]
     public static bool SlideCollectionContainer_UnloadStreamingTextures(SlideCollectionContainer __instance)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             for (int i = 0; i < (container.slideCollection as NHSlideCollection).slidePaths.Length; i++)
             {
@@ -117,7 +118,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.GetStreamingTexture))]
     public static bool SlideCollectionContainer_GetStreamingTexture(SlideCollectionContainer __instance, int id, ref Texture __result)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             __result = (container.slideCollection as NHSlideCollection).LoadSlide(id);
             return false;
@@ -132,7 +133,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.RequestManualStreamSlides))]
     public static bool SlideCollectionContainer_RequestManualStreamSlides(SlideCollectionContainer __instance)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             (container.slideCollection as NHSlideCollection).LoadSlide(__instance._currentSlideIndex);
             return false;
@@ -147,7 +148,7 @@ public class NHSlideCollectionContainer : SlideCollectionContainer
     [HarmonyPatch(typeof(SlideCollectionContainer), nameof(SlideCollectionContainer.streamingTexturesAvailable), MethodType.Getter)]
     public static bool SlideCollectionContainer_streamingTexturesAvailable(SlideCollectionContainer __instance, ref bool __result)
     {
-        if (__instance is NHSlideCollectionContainer container)
+        if (__instance is NHSlideCollectionContainer container && container.doAsyncLoading)
         {
             __result = (container.slideCollection as NHSlideCollection).slidePaths != null && (container.slideCollection as NHSlideCollection).slidePaths.Any();
             return false;

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/ProjectionInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/ProjectionInfo.cs
@@ -85,6 +85,12 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// Exclusive to the slide reel type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted is a burned reel.
         /// </summary>
         [DefaultValue("antique")] public SlideReelCondition reelCondition = SlideReelCondition.Antique;
-    }
 
+        /// <summary>
+        /// Set which slides appear on the slide reel model. Leave empty to default to the first few slides.
+        /// Takes a list of indices, i.e., to show the first 5 slides in reverse you would put [4, 3, 2, 1, 0].
+        /// Index starts at 0.
+        /// </summary>
+        public int[] displaySlides;
+    }
 }

--- a/NewHorizons/Patches/ShipLogPatches/ShipLogSlideReelPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogSlideReelPatches.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+using NewHorizons.Components.EOTE;
+
+namespace NewHorizons.Patches.ShipLogPatches;
+
+[HarmonyPatch]
+public static class ShipLogSlideReelPatches
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(ShipLogSlideProjector), nameof(ShipLogSlideProjector.CheckStreamingTexturesAvailable))]
+    public static bool ShipLogSlideProjector_CheckStreamingTexturesAvailable(ShipLogSlideProjector __instance, ref bool __result)
+    {
+        if (__instance._collectionIndex >= 0 && __instance._collectionIndex < __instance._slideCollections.Count &&
+            __instance._slideCollections[__instance._collectionIndex] is NHSlideCollection)
+        {
+            __result = true;
+            return false;
+        }
+        return true;
+    }
+}

--- a/NewHorizons/Patches/ShipLogPatches/ShipLogSlideReelPatches.cs
+++ b/NewHorizons/Patches/ShipLogPatches/ShipLogSlideReelPatches.cs
@@ -18,4 +18,20 @@ public static class ShipLogSlideReelPatches
         }
         return true;
     }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(ShipLogSlideProjector), nameof(ShipLogSlideProjector.UnloadCurrentStreamingTextures))]
+    public static bool ShipLogSlideProjector_UnloadCurrentStreamingTextures(ShipLogSlideProjector __instance)
+    {
+        if (__instance._collectionIndex >= 0 && __instance._collectionIndex < __instance._slideCollections.Count &&
+            __instance._slideCollections[__instance._collectionIndex] is NHSlideCollection collection)
+        {
+            for (int i = 0; i < collection.slides.Length; i++)
+            {
+                collection.UnloadSlide(i);
+            }
+            return false;
+        }
+        return true;
+    }
 }

--- a/NewHorizons/Patches/ToolPatches/ToolModeSwapperPatches.cs
+++ b/NewHorizons/Patches/ToolPatches/ToolModeSwapperPatches.cs
@@ -5,6 +5,8 @@ namespace NewHorizons.Patches.ToolPatches
     [HarmonyPatch(typeof(ToolModeSwapper))]
     public static class ToolModeSwapperPatches
     {
+        private static ShipCockpitController _shipCockpitController;
+
         // Patches ToolModeSwapper.EquipToolMode(ToolMode mode) to deny swaps if you're holding a vision torch.
         // This is critical for preventing swapping to the scout launcher (causes memory slides to fail) but it
         // just doesn't look right when you switch to other stuff (eg the signalscope), so I'm disabling swapping tools entirely
@@ -21,7 +23,9 @@ namespace NewHorizons.Patches.ToolPatches
                 mode == ToolMode.Probe ||
                 mode == ToolMode.SignalScope ||
                 mode == ToolMode.Translator;
-            var isInShip = UnityEngine.Object.FindObjectOfType<ShipCockpitController>()?._playerAtFlightConsole ?? false;
+            if (_shipCockpitController == null)
+                _shipCockpitController = UnityEngine.Object.FindObjectOfType<ShipCockpitController>();
+            var isInShip = _shipCockpitController != null ? _shipCockpitController._playerAtFlightConsole : false;
 
             if (!isInShip && isHoldingVisionTorch && swappingToRestrictedTool) return false;
 

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2863,6 +2863,14 @@
           "description": "Exclusive to the slide reel type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted is a burned reel.",
           "default": "antique",
           "$ref": "#/definitions/SlideReelCondition"
+        },
+        "displaySlides": {
+          "type": "array",
+          "description": "Set which slides appear on the slide reel model. Leave empty to default to the first few slides.\nTakes a list of indices, i.e., to show the first 5 slides in reverse you would put [4, 3, 2, 1, 0].\nIndex starts at 0.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
         }
       }
     },

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -71,6 +71,19 @@ namespace NewHorizons.Utility.Files
             }
         }
 
+        /// <summary>
+        /// Not sure why the other method takes in the texture as well
+        /// </summary>
+        /// <param name="key"></param>
+        public static void DeleteTexture(string key)
+        {
+            if (_textureCache.ContainsKey(key))
+            {
+                UnityEngine.Object.Destroy(_textureCache[key]);
+                _textureCache.Remove(key);
+            }
+        }
+
         public static void DeleteTexture(IModBehaviour mod, string filename, Texture2D texture)
         {
             var path = Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename);
@@ -194,9 +207,9 @@ namespace NewHorizons.Utility.Files
                     {
                         for (int j = 0; j < size; j++)
                         {
-                            var colour = Color.black;
+                            var colour = Color.clear;
 
-                            if (srcTexture)
+                            if (srcTexture != null)
                             {
                                 var srcX = i * srcTexture.width / (float)size;
                                 var srcY = j * srcTexture.height / (float)size;

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -47,7 +47,7 @@ namespace NewHorizons.Utility.Files
             var key = GetKey(path);
             if (_textureCache.TryGetValue(key, out var existingTexture))
             {
-                NHLogger.LogVerbose($"Already loaded image at path: {path}");
+                //NHLogger.LogVerbose($"Already loaded image at path: {path}");
                 return (Texture2D)existingTexture;
             }
 

--- a/NewHorizons/Utility/Files/ImageUtilities.cs
+++ b/NewHorizons/Utility/Files/ImageUtilities.cs
@@ -15,6 +15,9 @@ namespace NewHorizons.Utility.Files
         public static bool CheckCachedTexture(string key, out Texture existingTexture) => _textureCache.TryGetValue(key, out existingTexture);
         public static void TrackCachedTexture(string key, Texture texture) => _textureCache.Add(key, texture); // dont reinsert cuz that causes memory leak!
 
+        public static string GetKey(IModBehaviour mod, string filename)
+            => GetKey(Path.Combine(mod.ModHelper.Manifest.ModFolderPath, filename));
+
         public static string GetKey(string path) =>
             path.Substring(Main.Instance.ModHelper.OwmlConfig.ModsPath.Length + 1).Replace('\\', '/');
 

--- a/NewHorizons/Utility/Files/SlideReelAsyncImageLoader.cs
+++ b/NewHorizons/Utility/Files/SlideReelAsyncImageLoader.cs
@@ -42,6 +42,11 @@ public class SlideReelAsyncImageLoader
     private bool _started;
     private bool _clamp;
 
+    /// <summary>
+    /// start loading the images a frame later
+    /// </summary>
+    /// <param name="clamp">sets wrapMode</param>
+    /// <param name="sequential">load all slides one at a time vs at the same time</param>
     public void Start(bool clamp, bool sequential)
     {
         if (_started) return;


### PR DESCRIPTION
## Minor features
- Can set `displaySlides` on a slide reel now to define which slide indices should be displayed on the physical reel model. Fixes #888.

## Improvements

- Slide reels are now streamed (Fixes #898). Other projectors (auto, torch) are not streamed  yet.
- Empty slide reel slots are now transparent on the slide reel model. Requires existing slide reel caches to be cleared.

## Bug fixes

- Fixed a 3 frame hitch when changing tools


So the strategy is:
If the cache does not exist, do nothing different. It will take like 5 minutes and all your memory but that doesn't matter that's on the dev to make sure that they pre-gen the caches (the sequential pre-caching option should stop you running out of memory when making the cache probably). Users won't experience any of that

Then we just do not ever load the inverted cached images when loading slides from the cache. Only do it right as the player is about to see a slide, by patching any base game method that tries to get a streamed slide. We currently do not change how auto-projectors and vision torches work.

TODO:
- [x] Track who is requesting to load what image so that an unsocketed slide reel doesnt unload all slides
- [x] Investigate why load times are longer
- [x] Make loading the images async (on an SSD doing it sync is unnoticeable but might be on older hardware)
- [x] I need somebody to test this on an HDD and see that the slide reels are actually loading async without hitching
- [x] When slotting slide reels in on EOTP you get a ~3 frame drop. Does not affect NH Examples (smaller images). Need to figure out why (since this is meant to be async it shouldnt matter the image size)

In EOTP I save 6 seconds of load time and 3.5gb of memory (6.5gb vs 10gb)