### PR TITLE
Eye Travel Ordering

### DIFF
--- a/NewHorizons/External/Modules/Props/EyeOfTheUniverse/EyeTravelerInfo.cs
+++ b/NewHorizons/External/Modules/Props/EyeOfTheUniverse/EyeTravelerInfo.cs
@@ -1,6 +1,7 @@
 using NewHorizons.External.Modules.Props.Audio;
 using NewHorizons.External.Modules.Props.Dialogue;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace NewHorizons.External.Modules.Props.EyeOfTheUniverse
 {
@@ -46,5 +47,23 @@ namespace NewHorizons.External.Modules.Props.EyeOfTheUniverse
         /// The dialogue to use for this traveler. If omitted, the first CharacterDialogueTree in the object will be used.
         /// </summary>
         public DialogueInfo dialogue;
+
+        /// <summary>
+        /// The name of the base game traveler to position this traveler after at the campfire, starting clockwise from Riebeck. Defaults to the end of the list (right before Riebeck).
+        /// </summary>
+        public TravelerName? afterTraveler;
+
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum TravelerName
+        {
+            Riebeck,
+            Chert,
+            Esker,
+            Felspar,
+            Gabbro,
+            Solanum,
+            Prisoner,
+        }
     }
 }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1022,6 +1022,17 @@
         "dialogue": {
           "description": "The dialogue to use for this traveler. If omitted, the first CharacterDialogueTree in the object will be used.",
           "$ref": "#/definitions/DialogueInfo"
+        },
+        "afterTraveler": {
+          "description": "The name of the base game traveler to position this traveler after at the campfire, starting clockwise from Riebeck. Defaults to the end of the list (right before Riebeck).",
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/TravelerName"
+            }
+          ]
         }
       }
     },
@@ -1464,6 +1475,28 @@
         "turnOff",
         "turnOffThenOn",
         "none"
+      ]
+    },
+    "TravelerName": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "Riebeck",
+        "Chert",
+        "Esker",
+        "Felspar",
+        "Gabbro",
+        "Solanum",
+        "Prisoner"
+      ],
+      "enum": [
+        "Riebeck",
+        "Chert",
+        "Esker",
+        "Felspar",
+        "Gabbro",
+        "Solanum",
+        "Prisoner"
       ]
     },
     "InstrumentZoneInfo": {


### PR DESCRIPTION
## Minor features

- Add `afterTraveler` to custom Eye Travelers to place them after a base game traveler in the campfire order (resolves #1037)

## Improvements

- Fix order of travelers at the Eye when both base game guests have been gathered and custom travelers are used
