### PR TITLE
Item Collider Fixes

### DIFF
--- a/NewHorizons/Builder/Props/ItemBuilder.cs
+++ b/NewHorizons/Builder/Props/ItemBuilder.cs
@@ -1,6 +1,7 @@
 using NewHorizons.Components.Props;
 using NewHorizons.External.Modules.Props.Item;
 using NewHorizons.Handlers;
+using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
 using OWML.Utils;
@@ -27,6 +28,8 @@ namespace NewHorizons.Builder.Props
 
         public static NHItem MakeItem(GameObject go, GameObject planetGO, Sector sector, ItemInfo info, IModBehaviour mod)
         {
+            go.layer = Layer.Interactible;
+
             var itemName = info.name;
             if (string.IsNullOrEmpty(itemName))
             {
@@ -93,10 +96,13 @@ namespace NewHorizons.Builder.Props
 
             if (info.colliderRadius > 0f)
             {
-                go.AddComponent<SphereCollider>().radius = info.colliderRadius;
+                var col = go.AddComponent<SphereCollider>();
+                col.radius = info.colliderRadius;
+                col.isTrigger = info.colliderIsTrigger;
                 go.GetAddComponent<OWCollider>();
             }
 
+            // Wait until next frame when all objects are built before trying to socket the item if it has an initial socket
             Delay.FireOnNextUpdate(() =>
             {
                 if (item != null && !string.IsNullOrEmpty(info.pathToInitialSocket))
@@ -133,6 +139,8 @@ namespace NewHorizons.Builder.Props
 
         public static NHItemSocket MakeSocket(GameObject go, GameObject planetGO, Sector sector, ItemSocketInfo info)
         {
+            go.layer = Layer.Interactible;
+
             var itemType = EnumUtils.TryParse(info.itemType, true, out ItemType result) ? result : ItemType.Invalid;
             if (itemType == ItemType.Invalid && !string.IsNullOrEmpty(info.itemType))
             {
@@ -151,13 +159,16 @@ namespace NewHorizons.Builder.Props
             if (socket._socketTransform == null)
             {
                 var socketGO = GeneralPropBuilder.MakeNew("Socket", planetGO, sector, info, defaultParent: go.transform);
-                if (info.colliderRadius > 0f)
-                {
-                    go.AddComponent<SphereCollider>().radius = info.colliderRadius;
-                    go.GetAddComponent<OWCollider>();
-                }
                 socketGO.SetActive(true);
                 socket._socketTransform = socketGO.transform;
+            }
+
+            if (info.colliderRadius > 0f)
+            {
+                var col = go.AddComponent<SphereCollider>();
+                col.radius = info.colliderRadius;
+                col.isTrigger = info.colliderIsTrigger;
+                go.GetAddComponent<OWCollider>();
             }
 
             socket.ItemType = itemType;
@@ -169,6 +180,7 @@ namespace NewHorizons.Builder.Props
             socket.ClearRemovalConditionOnInsert = info.clearRemovalConditionOnInsert;
             socket.RemovalFact = info.removalFact;
 
+            // Wait until initial item socketing is done before considering the socket empty
             Delay.FireInNUpdates(() =>
             {
                 if (socket != null && !socket._socketedItem)

--- a/NewHorizons/Builder/Props/NomaiTextBuilder.cs
+++ b/NewHorizons/Builder/Props/NomaiTextBuilder.cs
@@ -312,7 +312,7 @@ namespace NewHorizons.Builder.Props
                                 scrollItem._nomaiWallText = nomaiWallText;
                                 scrollItem.SetSector(sector);
                                 customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Geo").GetComponent<MeshRenderer>().enabled = true;
-                                customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Collider").gameObject.SetActive(true);
+                                customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Collider").gameObject.SetActive(false);
                                 nomaiWallText.gameObject.GetComponent<Collider>().enabled = false;
                                 customScroll.GetComponent<CapsuleCollider>().enabled = true;
                             }

--- a/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
+++ b/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
@@ -206,7 +206,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                                 scrollItem._nomaiWallText = nomaiWallText;
                                 scrollItem.SetSector(sector);
                                 customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Geo").GetComponent<MeshRenderer>().enabled = true;
-                                customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Collider").gameObject.SetActive(true);
+                                customScroll.transform.Find("Props_NOM_Scroll/Props_NOM_Scroll_Collider").gameObject.SetActive(false);
                                 nomaiWallText.gameObject.GetComponent<Collider>().enabled = false;
                                 customScroll.GetComponent<CapsuleCollider>().enabled = true;
                                 scrollItem._nomaiWallText.HideImmediate();

--- a/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
+++ b/NewHorizons/External/Modules/Props/Item/ItemInfo.cs
@@ -32,6 +32,10 @@ namespace NewHorizons.External.Modules.Props.Item
         /// </summary>
         [DefaultValue(0.5f)] public float colliderRadius = 0.5f;
         /// <summary>
+        /// Whether the added sphere collider will be a trigger (interactible but does not collide). Defaults to true.
+        /// </summary>
+        [DefaultValue(true)] public bool colliderIsTrigger = true;
+        /// <summary>
         /// Whether the item can be dropped. Defaults to true.
         /// </summary>
         [DefaultValue(true)] public bool droppable = true;

--- a/NewHorizons/External/Modules/Props/Item/ItemSocketInfo.cs
+++ b/NewHorizons/External/Modules/Props/Item/ItemSocketInfo.cs
@@ -19,6 +19,15 @@ namespace NewHorizons.External.Modules.Props.Item
         /// </summary>
         [DefaultValue(2f)] public float interactRange = 2f;
         /// <summary>
+        /// Default collider radius when interacting with the socket
+        /// </summary>
+        [DefaultValue(0f)]
+        public float colliderRadius = 0f;
+        /// <summary>
+        /// Whether the added sphere collider will be a trigger (interactible but does not collide). Defaults to true.
+        /// </summary>
+        [DefaultValue(true)] public bool colliderIsTrigger = true;
+        /// <summary>
         /// Whether to use "Give Item" / "Take Item" prompts instead of "Insert Item" / "Remove Item".
         /// </summary>
         public bool useGiveTakePrompts;
@@ -46,10 +55,5 @@ namespace NewHorizons.External.Modules.Props.Item
         /// A ship log fact to reveal when removing an item from this socket, or when the socket is empty.
         /// </summary>
         public string removalFact;
-        /// <summary>
-        /// Default collider radius when interacting with the socket
-        /// </summary>
-        [DefaultValue(0f)]
-        public float colliderRadius = 0f;
     }
 }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -1121,6 +1121,11 @@
           "format": "float",
           "default": 0.5
         },
+        "colliderIsTrigger": {
+          "type": "boolean",
+          "description": "Whether the added sphere collider will be a trigger (interactible but does not collide). Defaults to true.",
+          "default": true
+        },
         "droppable": {
           "type": "boolean",
           "description": "Whether the item can be dropped. Defaults to true.",
@@ -1230,6 +1235,17 @@
           "format": "float",
           "default": 2.0
         },
+        "colliderRadius": {
+          "type": "number",
+          "description": "Default collider radius when interacting with the socket",
+          "format": "float",
+          "default": 0.0
+        },
+        "colliderIsTrigger": {
+          "type": "boolean",
+          "description": "Whether the added sphere collider will be a trigger (interactible but does not collide). Defaults to true.",
+          "default": true
+        },
         "useGiveTakePrompts": {
           "type": "boolean",
           "description": "Whether to use \"Give Item\" / \"Take Item\" prompts instead of \"Insert Item\" / \"Remove Item\"."
@@ -1259,12 +1275,6 @@
         "removalFact": {
           "type": "string",
           "description": "A ship log fact to reveal when removing an item from this socket, or when the socket is empty."
-        },
-        "colliderRadius": {
-          "type": "number",
-          "description": "Default collider radius when interacting with the socket",
-          "format": "float",
-          "default": 0.0
         }
       }
     },


### PR DESCRIPTION
## Improvements

- The sphere colliders added to custom items and item sockets to make them interactible no longer have collision by default. Mod authors can restore the previous behavior by setting `colliderIsTrigger` to false. Resolves #1054.
- Nomai scrolls created using `translatorTexts` no longer have collision. This matches how scrolls behave in the base game.