### PR TITLE
Fixes for Immediately Disabled Details

### DIFF
--- a/NewHorizons/Builder/General/GroupsBuilder.cs
+++ b/NewHorizons/Builder/General/GroupsBuilder.cs
@@ -25,5 +25,8 @@ public static class GroupsBuilder
         go.GetAddComponent<SectorCullGroup>()._sector = sector;
         go.GetAddComponent<SectorCollisionGroup>()._sector = sector;
         go.GetAddComponent<SectorLightsCullGroup>()._sector = sector;
+
+        // SectorCollisionGroup is unique among the sector groups because it only attaches its event listener on Start() instead of Awake(), so if the detail gets immediately deactivated then it never gets attached. To avoid this, we'll attach the event listener manually (even if it means getting attached twice).
+        sector.OnSectorOccupantsUpdated += go.GetComponent<SectorCollisionGroup>().OnSectorOccupantsUpdated;
     }
 }

--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -356,7 +356,10 @@ namespace NewHorizons.Builder.Props
                     singleLightSensor._sector.OnSectorOccupantsUpdated -= singleLightSensor.OnSectorOccupantsUpdated;
                 }
                 singleLightSensor._sector = sector;
-                singleLightSensor._sector.OnSectorOccupantsUpdated += singleLightSensor.OnSectorOccupantsUpdated;
+                if (singleLightSensor._sector != null)
+                {
+                    singleLightSensor._sector.OnSectorOccupantsUpdated += singleLightSensor.OnSectorOccupantsUpdated;
+                }
             }
         }
 

--- a/NewHorizons/Handlers/EyeSceneHandler.cs
+++ b/NewHorizons/Handlers/EyeSceneHandler.cs
@@ -185,6 +185,12 @@ namespace NewHorizons.Handlers
             starLightController.Awake();
             SunLightEffectsController.AddStar(starController);
             SunLightEffectsController.AddStarLight(sunLight);
+
+            // The player starts out already added to the eye sector, so we need to inform the sectored components that the sector isn't empty
+            Delay.FireOnNextUpdate(() =>
+            {
+                eyeSector.OnSectorOccupantsUpdated.Invoke();
+            });
         }
 
         public static void SetUpEyeCampfireSequence()

--- a/NewHorizons/Handlers/EyeSceneHandler.cs
+++ b/NewHorizons/Handlers/EyeSceneHandler.cs
@@ -185,12 +185,6 @@ namespace NewHorizons.Handlers
             starLightController.Awake();
             SunLightEffectsController.AddStar(starController);
             SunLightEffectsController.AddStarLight(sunLight);
-
-            // The player starts out already added to the eye sector, so we need to inform the sectored components that the sector isn't empty
-            Delay.FireOnNextUpdate(() =>
-            {
-                eyeSector.OnSectorOccupantsUpdated.Invoke();
-            });
         }
 
         public static void SetUpEyeCampfireSequence()

--- a/NewHorizons/Patches/EchoesOfTheEyePatches/SingleLightSensorPatches.cs
+++ b/NewHorizons/Patches/EchoesOfTheEyePatches/SingleLightSensorPatches.cs
@@ -1,0 +1,24 @@
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NewHorizons.Patches.EchoesOfTheEyePatches
+{
+    [HarmonyPatch(typeof(SingleLightSensor))]
+    public static class SingleLightSensorPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(SingleLightSensor.Start))]
+        public static void Start(SingleLightSensor __instance)
+        {
+            // SingleLightSensor assumes that the sector will be empty when it starts and disables itself, but this may not be true if it starts disabled and is activated later, or spawned via the API
+            if (__instance._sector && __instance._sector.ContainsAnyOccupants(DynamicOccupant.Player | DynamicOccupant.Probe))
+            {
+                __instance.OnSectorOccupantsUpdated();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Bug fixes

- Fixed details not having collision if they were immediately deactivated after being created (for instance, via `activationCondition`)
- Fixed light sensors disabling themselves on activation if their detail was immediately deactivated after being created