### PR TITLE
Add debug bramble name labels

### DIFF
--- a/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
+++ b/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
@@ -5,6 +5,7 @@ using NewHorizons.External;
 using NewHorizons.External.Modules;
 using NewHorizons.External.Modules.Props;
 using NewHorizons.Utility;
+using NewHorizons.Utility.DebugTools;
 using NewHorizons.Utility.Files;
 using NewHorizons.Utility.OWML;
 using OWML.Common;
@@ -189,6 +190,7 @@ namespace NewHorizons.Builder.Body
             outerFogWarpVolume._linkedInnerWarpVolume = null;
             outerFogWarpVolume._name = OuterFogWarpVolume.Name.None;
             outerFogWarpVolume._sector = sector;
+            exitWarps.GetAddComponent<DebugFogWarp>().fogWarpVolume = outerFogWarpVolume;
 
             PairExit(config.linksTo, outerFogWarpVolume);
 

--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -4,6 +4,7 @@ using NewHorizons.External.Configs;
 using NewHorizons.External.Modules.Props.Audio;
 using NewHorizons.Handlers;
 using NewHorizons.Utility;
+using NewHorizons.Utility.DebugTools;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
 using Newtonsoft.Json;
@@ -204,6 +205,10 @@ namespace NewHorizons.Builder.Props
             foreach (var fogWarpVolume in brambleNode.GetComponentsInChildren<FogWarpVolume>(true).Append(brambleNode.GetComponent<FogWarpVolume>()))
             {
                 _nhFogWarpVolumes.Add(fogWarpVolume);
+                if (fogWarpVolume is SphericalFogWarpVolume sphericalFogWarpVolume)
+                {
+                    fogWarpVolume.gameObject.GetAddComponent<DebugFogWarp>().fogWarpVolume = sphericalFogWarpVolume;
+                }
             }
 
             var innerFogWarpVolume = brambleNode.GetComponent<InnerFogWarpVolume>();

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -46,6 +46,7 @@ namespace NewHorizons
         // Settings
         public static bool Debug { get; private set; }
         public static bool VisualizeQuantumObjects { get; private set; }
+        public static bool VisualizeBrambleVolumeNames { get; private set; }
         public static bool VerboseLogs { get; private set; }
         public static bool SequentialPreCaching { get; private set; }
         public static bool CustomTitleScreen { get; private set; }
@@ -138,6 +139,7 @@ namespace NewHorizons
 
             Debug = config.GetSettingsValue<bool>(nameof(Debug));
             VisualizeQuantumObjects = config.GetSettingsValue<bool>(nameof(VisualizeQuantumObjects));
+            VisualizeBrambleVolumeNames = config.GetSettingsValue<bool>(nameof(VisualizeBrambleVolumeNames));
             VerboseLogs = config.GetSettingsValue<bool>(nameof(VerboseLogs));
             SequentialPreCaching = config.GetSettingsValue<bool>(nameof(SequentialPreCaching));
 

--- a/NewHorizons/Utility/DebugTools/DebugFogWarp.cs
+++ b/NewHorizons/Utility/DebugTools/DebugFogWarp.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace NewHorizons.Utility.DebugTools
+{
+    /// <summary>
+    /// Adapted from Survivors https://github.com/Hawkbat/ow-mod-jam-2/blob/main/EscapePodFour.cs#L197
+    /// </summary>
+    [RequireComponent(typeof(SphericalFogWarpVolume))]
+    public class DebugFogWarp : MonoBehaviour
+    {
+        public SphericalFogWarpVolume fogWarpVolume;
+        public void OnGUI()
+        {
+            if (Main.Debug && Main.VisualizeBrambleVolumeNames && fogWarpVolume != null)
+            {
+                DrawWorldLabel(fogWarpVolume, fogWarpVolume.name);
+                if (fogWarpVolume._exits != null)
+                {
+                    foreach (var e in fogWarpVolume._exits)
+                    {
+                        if (e != null)
+                        {
+                            DrawWorldLabel(fogWarpVolume.GetExitPosition(e), e.name);
+                        }
+                    }
+                }
+            }
+        }
+
+        public void DrawWorldLabel(Component component, string text)
+        {
+            DrawWorldLabel(component.transform.position, text);
+        }
+
+        public void DrawWorldLabel(Vector3 worldPos, string text)
+        {
+            var c = Locator.GetPlayerCamera();
+            var d = Vector3.Distance(c.transform.position, worldPos);
+            if (d > 1000f) return;
+            GUI.Label(new Rect(WorldToGui(worldPos), new Vector2(500f, 20f)), text);
+        }
+
+        public Vector2 WorldToGui(Vector3 wp)
+        {
+            var c = Locator.GetPlayerCamera();
+            var sp = c.WorldToScreenPoint(wp);
+            if (sp.z < 0) return new Vector2(Screen.width, Screen.height);
+            var gp = new Vector2(sp.x, Screen.height - sp.y);
+            return gp;
+        }
+    }
+}

--- a/NewHorizons/default-config.json
+++ b/NewHorizons/default-config.json
@@ -22,6 +22,12 @@
       "value": false,
       "tooltip": "Draws boundaries around quantum objects when Debug mode is on."
     },
+    "VisualizeBrambleVolumeNames": {
+      "title": "Visualize Bramble Volume Names",
+      "type": "toggle",
+      "value": false,
+      "tooltip": "Adds a label to all custom spherical fog warp volumes and entrances/exits when Debug mode is on."
+    },
     "VerboseLogs": {
       "title": "Verbose Logs",
       "type": "toggle",


### PR DESCRIPTION
## Minor features

- Added a debug option for visualizing the names of custom bramble warp volumes and their entrances/exits. Resolves #1066