### PR TITLE
Allow comet tails on vanilla bodies

### DIFF
--- a/NewHorizons/Builder/Body/CometTailBuilder.cs
+++ b/NewHorizons/Builder/Body/CometTailBuilder.cs
@@ -74,7 +74,7 @@ namespace NewHorizons.Builder.Body
 
             if (string.IsNullOrEmpty(cometTailModule.primaryBody))
                 cometTailModule.primaryBody = !string.IsNullOrEmpty(config.Orbit.primaryBody) ? config.Orbit.primaryBody
-                    : (primaryBody._name == AstroObject.Name.CustomString ? primaryBody.GetCustomName() : primaryBody._name.ToString());
+                    : primaryBody.GetKey();
 
             var rootObj = new GameObject("CometRoot");
             rootObj.SetActive(false);

--- a/NewHorizons/Builder/Body/ProxyBuilder.cs
+++ b/NewHorizons/Builder/Body/ProxyBuilder.cs
@@ -203,7 +203,7 @@ namespace NewHorizons.Builder.Body
 
                 if (body.Config.CometTail != null)
                 {
-                    CometTailBuilder.Make(proxy, null, body.Config.CometTail, body.Config);
+                    CometTailBuilder.Make(proxy, null, body.Config.CometTail, body.Config, planetGO.GetComponent<AstroObject>());
                 }
 
                 if (body.Config.Props?.proxyDetails != null)

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -657,7 +657,7 @@ namespace NewHorizons.Handlers
 
             if (body.Config.CometTail != null)
             {
-                CometTailBuilder.Make(go, sector, body.Config.CometTail, body.Config);
+                CometTailBuilder.Make(go, sector, body.Config.CometTail, body.Config, go.GetComponent<AstroObject>());
             }
 
             if (body.Config.Lava != null)

--- a/NewHorizons/Utility/NewHorizonExtensions.cs
+++ b/NewHorizons/Utility/NewHorizonExtensions.cs
@@ -445,6 +445,11 @@ namespace NewHorizons.Utility
             return globalMusicController._endTimesSource.clip.length;
         }
 
+        public static string GetKey(this AstroObject ao)
+        {
+            return ao._name == AstroObject.Name.CustomString ? ao.GetCustomName() : ao._name.ToString();
+        }
+
         public static CodeMatcher LogInstructions(this CodeMatcher matcher, string prefix)
         {
             matcher.InstructionEnumeration().LogInstructions(prefix);

--- a/NewHorizons/Utility/OuterWilds/AstroObjectLocator.cs
+++ b/NewHorizons/Utility/OuterWilds/AstroObjectLocator.cs
@@ -65,7 +65,7 @@ namespace NewHorizons.Utility.OuterWilds
 
         public static void RegisterCustomAstroObject(AstroObject ao)
         {
-            var key = ao._name == AstroObject.Name.CustomString ? ao.GetCustomName() : ao._name.ToString();
+            var key = ao.GetKey();
 
             if (_customAstroObjectDictionary.ContainsKey(key))
             {
@@ -81,7 +81,7 @@ namespace NewHorizons.Utility.OuterWilds
 
         public static void DeregisterCustomAstroObject(AstroObject ao)
         {
-            var key = ao._name == AstroObject.Name.CustomString ? ao.GetCustomName() : ao._name.ToString();
+            var key = ao.GetKey();
             _customAstroObjectDictionary.Remove(key);
         }
 


### PR DESCRIPTION
Made this because I tried to add a comet tail to ember twin but it kept saying `Comet CaveTwin_Body does not orbit anything. That makes no sense` because Orbit.primaryBody didn't have anything.
So now it grabs the primary body from the astro object but also takes into account Orbit.primaryBody
![image](https://github.com/user-attachments/assets/bf79b4cb-b79c-4adc-af32-c0b09bf11a72)


## Bug fixes

- Fixed a bug that didn't allow comet tails to be made on unmoved vanilla planets/moons.