### PR TITLE
Fix Build Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,4 +65,4 @@ jobs:
       - name: Check Changed Schemas
         id: changed_files
         run: |
-          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas 2>&1>$null && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas 2>&1>$null && echo false || echo true)" >> $Env:GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,4 +65,4 @@ jobs:
       - name: Check Changed Schemas
         id: changed_files
         run: |
-          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas >/dev/null 2>&1 && echo false || echo true)" >> $GITHUB_OUTPUT
+          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas 2>&1>$null && echo false || echo true)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,8 +62,7 @@ jobs:
           name: NewHorizons-Schemas-${{ inputs.build_type }}
           path: .\NewHorizons\Schemas
 
-      - name: Verify Changed Schemas
-        uses: tj-actions/verify-changed-files@v20
+      - name: Check Changed Schemas
         id: changed_files
-        with:
-          files: NewHorizons/Schemas/**
+        run: |
+          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas >/dev/null 2>&1 && echo false || echo true)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Build workflow uses a non-existent action to check changed files. Switched it out for a simple call to `git`.

We'll need to:

1. Merge this to `main` so version PRs are updated correctly
2. Merge `main` to `dev` so feature PRs are updated
3. Every other branch should try to merge this in from `dev`