### PR TITLE
Destroy flood sensors on docks

### DIFF
--- a/NewHorizons/Builder/Props/DetailBuilder.cs
+++ b/NewHorizons/Builder/Props/DetailBuilder.cs
@@ -473,9 +473,13 @@ namespace NewHorizons.Builder.Props
             {
                 // These flood toggles are to disable flooded docks on the Stranger
                 // Presumably the user isn't making one of those
-                foreach (var toggle in dock.GetComponents<FloodToggle>())
+                foreach (var toggle in dock.GetComponents<FloodToggle>().Concat(dock.GetComponentsInChildren<FloodToggle>()))
                 {
                     Component.DestroyImmediate(toggle);
+                }
+                foreach (var floodSensor in dock.GetComponents<RingRiverFloodSensor>().Concat(dock.GetComponentsInChildren<RingRiverFloodSensor>()))
+                {
+                    Component.DestroyImmediate(floodSensor);
                 }
             }
         }


### PR DESCRIPTION
## Bug fixes

- Make docks not vanish when the dam breaks (maybe, needs testing)
