### PR TITLE
Docked Rafts and Clean Rafts

### DIFF
--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
@@ -5,7 +5,7 @@ using NewHorizons.Utility;
 using NewHorizons.Utility.OWML;
 using UnityEngine;
 
-namespace NewHorizons.Builder.Props
+namespace NewHorizons.Builder.Props.EchoesOfTheEye
 {
     public static class RaftBuilder
     {
@@ -90,6 +90,21 @@ namespace NewHorizons.Builder.Props
             achievementObject.AddComponent<OtherMods.AchievementsPlus.NH.RaftingAchievement>();
 
             raftObject.SetActive(true);
+
+            if (planetGO != null && !string.IsNullOrEmpty(info.dockPath))
+            {
+                var dockTransform = planetGO.transform.Find(info.dockPath);
+                if (dockTransform != null && dockTransform.TryGetComponent(out RaftDock raftDock))
+                {
+                    raftController.SkipSuspendOnStart();
+                    raftDock._startRaft = raftController;
+                    raftDock._raft = raftController;
+                }
+                else
+                {
+                    NHLogger.LogError($"Cannot find raft dock object at path: {planetGO.name}/{info.dockPath}");
+                }
+            }
 
             return raftObject;
         }

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
@@ -45,6 +45,15 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
                         lightSensor._illuminatingDreamLanternList = new List<DreamLanternController>();
                         lightSensor._lightSourceMask |= LightSourceType.DREAM_LANTERN;
                     }
+
+                    // TODO: Change to one mesh
+                    var twRaftRoot = new GameObject("Effects_IP_SIM_Raft");
+                    twRaftRoot.transform.SetParent(_prefab.transform, false);
+                    var twRaft = SearchUtilities.Find("DreamWorld_Body/Sector_DreamWorld/Interactibles_Dreamworld/DreamRaft_Body/Effects_IP_SIM_Raft_1Way")
+                        .Instantiate(Vector3.zero, Quaternion.identity, twRaftRoot.transform).Rename("Effects_IP_SIM_Raft_1Way");
+                    twRaft.Instantiate(Vector3.zero, Quaternion.Euler(0, 180, 0), twRaftRoot.transform).Rename(twRaft.name);
+                    twRaft.Instantiate(Vector3.zero, Quaternion.Euler(0, 90, 0), twRaftRoot.transform).Rename(twRaft.name);
+                    twRaft.Instantiate(Vector3.zero, Quaternion.Euler(0, -90, 0), twRaftRoot.transform).Rename(twRaft.name);
                 }
             }
         }

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
@@ -119,7 +119,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || _cleanPrefab == null || sector == null) return null;
 
-            GameObject raftObject = GeneralPropBuilder.MakeFromPrefab(info.clean ? _cleanPrefab : _prefab, "Raft_Body", planetGO, sector, info);
+            GameObject raftObject = GeneralPropBuilder.MakeFromPrefab(info.pristine ? _cleanPrefab : _prefab, "Raft_Body", planetGO, sector, info);
 
             StreamingHandler.SetUpStreaming(raftObject, sector);
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
@@ -40,6 +40,10 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
                             lightSensor._sector.OnSectorOccupantsUpdated -= lightSensor.OnSectorOccupantsUpdated;
                             lightSensor._sector = null;
                         }
+                        lightSensor._detectDreamLanterns = true;
+                        lightSensor._lanternFocusThreshold = 0.9f;
+                        lightSensor._illuminatingDreamLanternList = new List<DreamLanternController>();
+                        lightSensor._lightSourceMask |= LightSourceType.DREAM_LANTERN;
                     }
                 }
             }

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
@@ -1,0 +1,51 @@
+using NewHorizons.Components.Props;
+using NewHorizons.External.Modules.Props;
+using NewHorizons.External.Modules.Props.EchoesOfTheEye;
+using NewHorizons.Handlers;
+using NewHorizons.Utility;
+using NewHorizons.Utility.OWML;
+using OWML.Common;
+using UnityEngine;
+
+namespace NewHorizons.Builder.Props.EchoesOfTheEye
+{
+    public static class RaftDockBuilder
+    {
+        private static GameObject _prefab;
+
+        internal static void InitPrefab()
+        {
+            if (_prefab == null)
+            {
+                _prefab = SearchUtilities.Find("RingWorld_Body/Sector_RingInterior/Sector_Zone1/Structures_Zone1/RaftHouse_ArrivalPatio_Zone1/Interactables_RaftHouse_ArrivalPatio_Zone1/Prefab_IP_RaftDock").InstantiateInactive().Rename("Prefab_RaftDock").DontDestroyOnLoad();
+                if (_prefab == null)
+                {
+                    NHLogger.LogWarning($"Tried to make a raft dock but couldn't. Do you have the DLC installed?");
+                    return;
+                }
+                else
+                {
+                    _prefab.AddComponent<DestroyOnDLC>()._destroyOnDLCNotOwned = true;
+                    var raftDock = _prefab.GetComponent<RaftDock>();
+                    raftDock._startRaft = null;
+                    raftDock._floodSensor = null;
+                    Object.DestroyImmediate(_prefab.FindChild("FloodSensor"));
+                    Object.DestroyImmediate(_prefab.FindChild("FloodSensor_RaftHouseArrivalPatio_NoDelay"));
+                }
+            }
+        }
+
+        public static GameObject Make(GameObject planetGO, Sector sector, RaftDockInfo info, IModBehaviour mod)
+        {
+            InitPrefab();
+
+            if (_prefab == null || sector == null) return null;
+
+            var dockObject = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+
+            //var raftDock = dockObject.GetComponent<RaftDock>();
+
+            return dockObject;
+        }
+    }
+}

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
@@ -29,6 +29,10 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
                     var raftDock = _prefab.GetComponent<RaftDock>();
                     raftDock._startRaft = null;
                     raftDock._floodSensor = null;
+                    foreach (var floodToggle in _prefab.GetComponents<FloodToggle>())
+                    {
+                        Component.DestroyImmediate(floodToggle);
+                    }
                     Object.DestroyImmediate(_prefab.FindChild("FloodSensor"));
                     Object.DestroyImmediate(_prefab.FindChild("FloodSensor_RaftHouseArrivalPatio_NoDelay"));
                 }

--- a/NewHorizons/Builder/Props/PropBuildManager.cs
+++ b/NewHorizons/Builder/Props/PropBuildManager.cs
@@ -114,6 +114,7 @@ namespace NewHorizons.Builder.Props
                 MakeGeneralProps(go, config.Props.grappleTotems, (totem) => GrappleTotemBuilder.Make(go, sector, totem, mod));
                 MakeGeneralProps(go, config.Props.dreamCampfires, (campfire) => DreamCampfireBuilder.Make(go, sector, campfire, mod), (campfire) => campfire.id);
                 MakeGeneralProps(go, config.Props.dreamArrivalPoints, (point) => DreamArrivalPointBuilder.Make(go, sector, point, mod), (point) => point.id);
+                MakeGeneralProps(go, config.Props.raftDocks, (dock) => RaftDockBuilder.Make(go, sector, dock, mod));
                 MakeGeneralProps(go, config.Props.rafts, (raft) => RaftBuilder.Make(go, sector, raft, planetBody));
             }
             MakeGeneralProps(go, config.Props.tornados, (tornado) => TornadoBuilder.Make(go, sector, tornado, config.Atmosphere?.clouds != null));

--- a/NewHorizons/Builder/Volumes/SpeedLimiterVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/SpeedLimiterVolumeBuilder.cs
@@ -1,0 +1,20 @@
+using NewHorizons.Components.Volumes;
+using NewHorizons.External.Modules.Volumes.VolumeInfos;
+using UnityEngine;
+
+namespace NewHorizons.Builder.Volumes
+{
+    public static class SpeedLimiterVolumeBuilder
+    {
+        public static SpeedLimiterVolume Make(GameObject planetGO, Sector sector, SpeedLimiterVolumeInfo info)
+        {
+            var volume = VolumeBuilder.Make<SpeedLimiterVolume>(planetGO, sector, info);
+
+            volume.maxSpeed = info.maxSpeed;
+            volume.stoppingDistance = info.stoppingDistance;
+            volume.maxEntryAngle = info.maxEntryAngle;
+
+            return volume;
+        }
+    }
+}

--- a/NewHorizons/Builder/Volumes/VolumesBuildManager.cs
+++ b/NewHorizons/Builder/Volumes/VolumesBuildManager.cs
@@ -191,6 +191,13 @@ namespace NewHorizons.Builder.Volumes
                     SpeedTrapVolumeBuilder.Make(go, sector, speedTrapVolume);
                 }
             }
+            if (config.Volumes.speedLimiterVolumes != null)
+            {
+                foreach (var speedLimiterVolume in config.Volumes.speedLimiterVolumes)
+                {
+                    SpeedLimiterVolumeBuilder.Make(go, sector, speedLimiterVolume);
+                }
+            }
             if (config.Volumes.lightSourceVolumes != null)
             {
                 foreach (var lightSourceVolume in config.Volumes.lightSourceVolumes)

--- a/NewHorizons/Components/Volumes/SpeedLimiterVolume.cs
+++ b/NewHorizons/Components/Volumes/SpeedLimiterVolume.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+
+namespace NewHorizons.Components.Volumes
+{
+    public class SpeedLimiterVolume : BaseVolume
+    {
+        public float maxSpeed = 10f;
+        public float stoppingDistance = 100f;
+        public float maxEntryAngle = 60f;
+
+        private OWRigidbody _parentBody;
+        private List<TrackedBody> _trackedBodies = new List<TrackedBody>();
+        private bool _playerJustExitedDream;
+
+        public override void Awake()
+        {
+            _parentBody = GetComponentInParent<OWRigidbody>();
+            base.Awake();
+            GlobalMessenger.AddListener("ExitDreamWorld", OnExitDreamWorld);
+        }
+
+        public void Start()
+        {
+            enabled = false;
+        }
+
+        public override void OnDestroy()
+        {
+            base.OnDestroy();
+            GlobalMessenger.RemoveListener("ExitDreamWorld", OnExitDreamWorld);
+        }
+
+        public void FixedUpdate()
+        {
+            foreach (var trackedBody in _trackedBodies)
+            {
+                bool slowed = false;
+                Vector3 velocity = trackedBody.body.GetVelocity() - _parentBody.GetVelocity();
+                float magnitude = velocity.magnitude;
+                if (magnitude <= maxSpeed)
+                {
+                    slowed = true;
+                }
+                else
+                {
+                    bool needsSlowing = true;
+                    float velocityReduction = trackedBody.deceleration * Time.deltaTime;
+                    float requiredReduction = maxSpeed - magnitude;
+                    if (requiredReduction > velocityReduction)
+                    {
+                        velocityReduction = requiredReduction;
+                        slowed = true;
+                    }
+                    if (trackedBody.name == Detector.Name.Ship)
+                    {
+                        Autopilot component = Locator.GetShipTransform().GetComponent<Autopilot>();
+                        if (component != null && component.IsFlyingToDestination())
+                        {
+                            needsSlowing = false;
+                        }
+                    }
+                    if (needsSlowing)
+                    {
+                        Vector3 velocityChange = velocityReduction * velocity.normalized;
+                        trackedBody.body.AddVelocityChange(velocityChange);
+                        if (trackedBody.name == Detector.Name.Ship && PlayerState.IsInsideShip())
+                        {
+                            Locator.GetPlayerBody().AddVelocityChange(velocityChange);
+                        }
+                    }
+                }
+                if (slowed)
+                {
+                    if (trackedBody.name == Detector.Name.Ship)
+                        GlobalMessenger.FireEvent("ShipExitSpeedLimiter");
+                    _trackedBodies.Remove(trackedBody);
+                    if (_trackedBodies.Count == 0)
+                        enabled = false;
+                }
+            }
+        }
+
+        private void OnExitDreamWorld()
+        {
+            _playerJustExitedDream = true;
+        }
+
+        public override void OnTriggerVolumeEntry(GameObject hitObj)
+        {
+            DynamicForceDetector component = hitObj.GetComponent<DynamicForceDetector>();
+            if (component == null || !component.CompareNameMask(Detector.Name.Player | Detector.Name.Probe | Detector.Name.Ship)) return;
+
+            if (component.GetName() == Detector.Name.Player && (PlayerState.IsInsideShip() || _playerJustExitedDream))
+            {
+                _playerJustExitedDream = false;
+            }
+            else
+            {
+                OWRigidbody attachedOWRigidbody = component.GetAttachedOWRigidbody();
+                Vector3 from = transform.position - attachedOWRigidbody.GetPosition();
+                Vector3 to = attachedOWRigidbody.GetVelocity() - _parentBody.GetVelocity();
+                float magnitude = to.magnitude;
+                if (magnitude > maxSpeed && Vector3.Angle(from, to) < maxEntryAngle)
+                {
+                    float deceleration = (maxSpeed * maxSpeed - magnitude * magnitude) / (2f * stoppingDistance);
+                    TrackedBody trackedBody = new TrackedBody(attachedOWRigidbody, component.GetName(), deceleration);
+                    _trackedBodies.Add(trackedBody);
+                    if (component.GetName() == Detector.Name.Ship)
+                        GlobalMessenger.FireEvent("ShipEnterSpeedLimiter");
+                    enabled = true;
+                }
+            }
+        }
+
+        public override void OnTriggerVolumeExit(GameObject hitObj)
+        {
+            DynamicForceDetector component = hitObj.GetComponent<DynamicForceDetector>();
+            if (component == null) return;
+
+            OWRigidbody body = component.GetAttachedOWRigidbody();
+            TrackedBody trackedBody = _trackedBodies.Find((TrackedBody i) => i.body == body);
+            if (trackedBody != null)
+            {
+                if (trackedBody.name == Detector.Name.Ship)
+                    GlobalMessenger.FireEvent("ShipExitSpeedLimiter");
+
+                _trackedBodies.Remove(trackedBody);
+
+                if (_trackedBodies.Count == 0)
+                    enabled = false;
+            }
+        }
+
+        [Serializable]
+        protected class TrackedBody
+        {
+            public OWRigidbody body;
+
+            public Detector.Name name;
+
+            public float deceleration;
+
+            public bool decelerated;
+
+            public TrackedBody(OWRigidbody body, Detector.Name name, float deceleration)
+            {
+                this.body = body;
+                this.name = name;
+                this.deceleration = deceleration;
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is TrackedBody trackedBody)
+                {
+                    return trackedBody.body == body && trackedBody.name == name;
+                }
+                return base.Equals(obj);
+            }
+
+            public override int GetHashCode() => body.GetHashCode();
+        }
+    }
+}

--- a/NewHorizons/External/Modules/PropModule.cs
+++ b/NewHorizons/External/Modules/PropModule.cs
@@ -59,6 +59,11 @@ namespace NewHorizons.External.Modules
         public RaftInfo[] rafts;
 
         /// <summary>
+        /// Add raft docks to this planet (requires Echoes of the Eye DLC)
+        /// </summary>
+        public RaftDockInfo[] raftDocks;
+
+        /// <summary>
         /// Scatter props around this planet's surface
         /// </summary>
         public ScatterInfo[] scatter;

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftDockInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftDockInfo.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+using System.ComponentModel;
+
+namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
+{
+    [JsonObject]
+    public class RaftDockInfo : GeneralPropInfo
+    {
+    }
+}

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
@@ -15,6 +15,11 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// Path to the dock this raft will start attached to.
         /// </summary>
         public string dockPath;
+
+        /// <summary>
+        /// Uses the raft model from the dreamworld
+        /// </summary>
+        public bool clean;
     }
 
 }

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
@@ -10,6 +10,11 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// Acceleration of the raft. Default acceleration is 5.
         /// </summary>
         [DefaultValue(5f)] public float acceleration = 5f;
+
+        /// <summary>
+        /// Path to the dock this raft will start attached to.
+        /// </summary>
+        public string dockPath;
     }
 
 }

--- a/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
+++ b/NewHorizons/External/Modules/Props/EchoesOfTheEye/RaftInfo.cs
@@ -19,7 +19,7 @@ namespace NewHorizons.External.Modules.Props.EchoesOfTheEye
         /// <summary>
         /// Uses the raft model from the dreamworld
         /// </summary>
-        public bool clean;
+        public bool pristine;
     }
 
 }

--- a/NewHorizons/External/Modules/Volumes/VolumeInfos/SpeedLimiterVolumeInfo.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumeInfos/SpeedLimiterVolumeInfo.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+using System.ComponentModel;
+using UnityEngine;
+
+namespace NewHorizons.External.Modules.Volumes.VolumeInfos
+{
+    [JsonObject]
+    public class SpeedLimiterVolumeInfo : VolumeInfo
+    {
+        /// <summary>
+        /// The speed the volume will slow you down to when you enter it.
+        /// </summary>
+        [DefaultValue(10f)]
+        public float maxSpeed = 10f;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DefaultValue(100f)]
+        public float stoppingDistance = 100f;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [DefaultValue(60f)]
+        public float maxEntryAngle = 60f;
+    }
+}

--- a/NewHorizons/External/Modules/Volumes/VolumesModule.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumesModule.cs
@@ -102,6 +102,13 @@ namespace NewHorizons.External.Modules.Volumes
         public SpeedTrapVolumeInfo[] speedTrapVolumes;
 
         /// <summary>
+        /// Add speed limiter volumes to this planet.
+        /// Slows down the player, ship, and probe when they enter this volume.
+        /// Used on the Stranger in DLC.
+        /// </summary>
+        public SpeedLimiterVolumeInfo[] speedLimiterVolumes;
+
+        /// <summary>
         /// Add visor effect volumes to this planet.
         /// </summary>
         public VisorEffectModule visorEffects;

--- a/NewHorizons/Main.cs
+++ b/NewHorizons/Main.cs
@@ -382,6 +382,7 @@ namespace NewHorizons
                         ProjectionBuilder.InitPrefabs();
                         CloakBuilder.InitPrefab();
                         RaftBuilder.InitPrefab();
+                        RaftDockBuilder.InitPrefab();
                         DreamCampfireBuilder.InitPrefab();
                         DreamArrivalPointBuilder.InitPrefab();
                     }

--- a/NewHorizons/Utility/NewHorizonExtensions.cs
+++ b/NewHorizons/Utility/NewHorizonExtensions.cs
@@ -274,6 +274,14 @@ namespace NewHorizons.Utility
             return UnityEngine.Object.Instantiate(original);
         }
 
+        public static GameObject Instantiate(this GameObject original, Vector3 localPosition, Quaternion localRotation, Transform parent)
+        {
+            var copy = UnityEngine.Object.Instantiate(original, parent, false);
+            copy.transform.localPosition = localPosition;
+            copy.transform.localRotation = localRotation;
+            return copy;
+        }
+
         public static T DontDestroyOnLoad<T>(this T target) where T : UnityEngine.Object
         {
             UnityEngine.Object.DontDestroyOnLoad(target);


### PR DESCRIPTION
## Minor features

- Added `raftDocks` to `Props`. An easier way to spawn in docks for rafts.
- Added `dockPath` to `RaftInfo`.  This is a path to the dock the raft will start attached to.
- Added `pristine` boolean to `RaftInfo`.  Makes the raft use the dreamworld model.

## Bug fixes

- NH-made rafts no longer skip a node when riding on the Dam's raft carrier.