### PR TITLE
Fix build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,8 @@ jobs:
           name: NewHorizons-Schemas-${{ inputs.build_type }}
           path: .\NewHorizons\Schemas
 
-      - name: Check Changed Schemas
+      - name: Verify Changed Schemas
+        uses: tj-actions/verify-changed-files@v20
         id: changed_files
-        run: |
-          echo "files_changed=$(git diff --exit-code NewHorizons/Schemas 2>&1>$null && echo false || echo true)" >> $Env:GITHUB_OUTPUT
+        with:
+          files: NewHorizons/Schemas/**

--- a/NewHorizons/Schemas/addon_manifest_schema.json
+++ b/NewHorizons/Schemas/addon_manifest_schema.json
@@ -103,6 +103,27 @@
           "type": "string",
           "description": "Condition that must be true for this game over to trigger. If this is on a LoadCreditsVolume, leave empty to always trigger this game over.\nNote this is a regular dialogue condition, not a persistent condition."
         },
+        "audio": {
+          "type": "string",
+          "description": "The audio to use for the credits music. Can be a path to a .wav/.ogg/.mp3 file, or taken from the AudioClip list.\nCredits will be silent unless this attribute is specified.\nNote: only applies when creditsType is set to \"custom\"."
+        },
+        "audioVolume": {
+          "type": "number",
+          "description": "The length of the fade in and out for the credits music.\nNote: only applies when creditsType is set to \"custom\".",
+          "format": "float",
+          "default": 1.0
+        },
+        "audioLooping": {
+          "type": "boolean",
+          "description": "Determines if the credits music should loop.\nNote: only applies when creditsType is set to \"custom\".",
+          "default": false
+        },
+        "length": {
+          "type": "number",
+          "description": "Duration of the credits scroll in seconds.\nNote: only applies when creditsType is set to \"custom\".",
+          "format": "float",
+          "default": 120.0
+        },
         "creditsType": {
           "description": "The type of credits that will run after the game over message is shown",
           "default": "fast",
@@ -152,12 +173,14 @@
         "Fast",
         "Final",
         "Kazoo",
+        "Custom",
         "None"
       ],
       "enum": [
         "fast",
         "final",
         "kazoo",
+        "custom",
         "none"
       ]
     }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -2964,7 +2964,7 @@
           "$ref": "#/definitions/SlideReelType"
         },
         "reelCondition": {
-          "description": "Exclusive to the slide reel type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted is a burned reel.",
+          "description": "Exclusive to the slide reel and standing vision torch type. Condition/material of the reel. Antique is the Stranger, Pristine is the Dreamworld, Rusted (exclusive to slide reels) is a burned reel.",
           "default": "antique",
           "$ref": "#/definitions/SlideReelCondition"
         },
@@ -6529,6 +6529,27 @@
           "type": "string",
           "description": "Condition that must be true for this game over to trigger. If this is on a LoadCreditsVolume, leave empty to always trigger this game over.\nNote this is a regular dialogue condition, not a persistent condition."
         },
+        "audio": {
+          "type": "string",
+          "description": "The audio to use for the credits music. Can be a path to a .wav/.ogg/.mp3 file, or taken from the AudioClip list.\nCredits will be silent unless this attribute is specified.\nNote: only applies when creditsType is set to \"custom\"."
+        },
+        "audioVolume": {
+          "type": "number",
+          "description": "The length of the fade in and out for the credits music.\nNote: only applies when creditsType is set to \"custom\".",
+          "format": "float",
+          "default": 1.0
+        },
+        "audioLooping": {
+          "type": "boolean",
+          "description": "Determines if the credits music should loop.\nNote: only applies when creditsType is set to \"custom\".",
+          "default": false
+        },
+        "length": {
+          "type": "number",
+          "description": "Duration of the credits scroll in seconds.\nNote: only applies when creditsType is set to \"custom\".",
+          "format": "float",
+          "default": 120.0
+        },
         "creditsType": {
           "description": "The type of credits that will run after the game over message is shown",
           "default": "fast",
@@ -6543,12 +6564,14 @@
         "Fast",
         "Final",
         "Kazoo",
+        "Custom",
         "None"
       ],
       "enum": [
         "fast",
         "final",
         "kazoo",
+        "custom",
         "none"
       ]
     },


### PR DESCRIPTION
The org that owned verify-changed-files got taken down because of a high security vulnerability in another one of their actions. Idiot switched to doing Powershell stuff to manually check, but then it kept breaking. The org fixed their vulnerability in that other action and is now back up so I'm just going to go back to using it and Idiot can go ahead and bring the Powershell stuff back if he ever feels like it