### PR TITLE
Fix held item volumes

### DIFF
--- a/NewHorizons/Builder/Props/ShapeBuilder.cs
+++ b/NewHorizons/Builder/Props/ShapeBuilder.cs
@@ -56,6 +56,7 @@ namespace NewHorizons.Builder.Props
                 // This is required for backwards compat (previously it defaulted to shapes)
                 // A common-ish puzzle is to put an insulating volume on a held item. Held items disabled all colliders when held, but don't disable shapes.
                 // Changing the default from shapes to colliders broke these puzzles
+                // The reason OWItem disables all colliders (even those that are just triggers) is presumably for scrolls which have nomai text as a trigger collider
                 if (info.hasCollision)
                 {
                     return AddCollider(go, info);

--- a/NewHorizons/Builder/Props/ShapeBuilder.cs
+++ b/NewHorizons/Builder/Props/ShapeBuilder.cs
@@ -19,18 +19,19 @@ namespace NewHorizons.Builder.Props
             {
                 var shapeOrCol = AddShapeOrCollider(go, info);
                 if (shapeOrCol is Shape shape)
+                {
                     owTriggerVolume._shape = shape;
+                }
                 else if (shapeOrCol is Collider col)
+                {
                     owTriggerVolume._owCollider = col.GetComponent<OWCollider>();
+                }
             }
             else
             {
-                var col = go.AddComponent<SphereCollider>();
-                col.radius = defaultRadius;
-                col.isTrigger = true;
-                var owCollider = go.GetAddComponent<OWCollider>();
-
-                owTriggerVolume._owCollider = owCollider;
+                var shape = go.AddComponent<SphereShape>();
+                shape.radius = defaultRadius;
+                owTriggerVolume._shape = shape;
             }
 
             return owTriggerVolume;

--- a/NewHorizons/Builder/Props/ShapeBuilder.cs
+++ b/NewHorizons/Builder/Props/ShapeBuilder.cs
@@ -42,17 +42,28 @@ namespace NewHorizons.Builder.Props
             {
                 // Explicitly add either a shape or collider if specified
                 if (info.useShape.Value)
+                {
                     return AddShape(go, info);
+                }
                 else
+                {
                     return AddCollider(go, info);
+                }
             }
             else
             {
-                // Prefer colliders over shapes if no preference is specified
-                if (info.type is ShapeType.Sphere or ShapeType.Box or ShapeType.Capsule)
+                // Prefer shapes over colliders if no preference is specified and not using collision
+                // This is required for backwards compat (previously it defaulted to shapes)
+                // A common-ish puzzle is to put an insulating volume on a held item. Held items disabled all colliders when held, but don't disable shapes.
+                // Changing the default from shapes to colliders broke these puzzles
+                if (info.hasCollision)
+                {
                     return AddCollider(go, info);
+                }
                 else
+                {
                     return AddShape(go, info);
+                }
             }
         }
 

--- a/NewHorizons/Builder/Volumes/VolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VolumeBuilder.cs
@@ -1,6 +1,7 @@
 using NewHorizons.Builder.Props;
 using NewHorizons.External.Modules.Volumes.VolumeInfos;
 using NewHorizons.Utility.OuterWilds;
+using NewHorizons.Utility.OWML;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Volumes
@@ -9,6 +10,23 @@ namespace NewHorizons.Builder.Volumes
     {
         public static TVolume MakeExisting<TVolume>(GameObject go, GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
         {
+            // Backwards compat for the two possible radii settings
+            // Both radii default to 1
+            if (info.shape != null && info.shape.type == External.Modules.Props.ShapeType.Sphere && info.shape.radius != info.radius)
+            {
+                // If the info shape radius if the default but the info radius is not the default, use it
+                if (info.shape.radius == 1f && info.radius != 1f)
+                {
+                    info.shape.radius = info.radius;
+                }
+            }
+
+            // Warning if you set the radius to not be one but are using a non sphere shape
+            if (info.radius != 1f && (info.shape != null && info.shape.type != External.Modules.Props.ShapeType.Sphere))
+            {
+                NHLogger.LogError($"Volume [{typeof(TVolume).Name}] on [{go.name}] has a radius value set but it's shape is [{info.shape.type}]");
+            }
+
             // Respect existing layer if set to a valid volume layer
             if (go.layer != Layer.AdvancedEffectVolume)
             {

--- a/NewHorizons/External/Modules/Props/ShapeInfo.cs
+++ b/NewHorizons/External/Modules/Props/ShapeInfo.cs
@@ -19,9 +19,9 @@ namespace NewHorizons.External.Modules.Props
         public ShapeType type = ShapeType.Sphere;
 
         /// <summary>
-        /// The radius of the shape or collider. Defaults to 0.5 meters. Only used by spheres, capsules, cylinders, hemispheres, hemicapsules, and rings.
+        /// The radius of the shape or collider. Defaults to 1 meter. Only used by spheres, capsules, cylinders, hemispheres, hemicapsules, and rings.
         /// </summary>
-        public float radius = 0.5f;
+        public float radius = 1f;
 
         /// <summary>
         /// The height of the shape or collider. Defaults to 1 meter. Only used by capsules, cylinders, cones, hemicapsules, and rings.
@@ -64,8 +64,9 @@ namespace NewHorizons.External.Modules.Props
         public bool hasCollision = false;
 
         /// <summary>
-        /// Whether to explicitly use a shape instead of a collider. Shapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. 
-        /// Defaults to using a shape, unless hasCollision is true where it defaults to using a collider.
+        /// Setting this to false will force it to use a collider, and setting to true will force it to use a shape.
+        /// Shapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. 
+        /// If left empty it will defaults to using a shape, unless hasCollision is true in which case it defaults to using a collider.
         /// </summary>
         public bool? useShape;
     }

--- a/NewHorizons/External/Modules/Props/ShapeInfo.cs
+++ b/NewHorizons/External/Modules/Props/ShapeInfo.cs
@@ -64,7 +64,8 @@ namespace NewHorizons.External.Modules.Props
         public bool hasCollision = false;
 
         /// <summary>
-        /// Whether to explicitly use a shape instead of a collider. Shapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. Omit this unless you explicitly want to use a sphere, box, or capsule shape instead of a collider.
+        /// Whether to explicitly use a shape instead of a collider. Shapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. 
+        /// Defaults to using a shape, unless hasCollision is true where it defaults to using a collider.
         /// </summary>
         public bool? useShape;
     }

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -5618,7 +5618,7 @@
         },
         "radius": {
           "type": "number",
-          "description": "The radius of the shape or collider. Defaults to 0.5 meters. Only used by spheres, capsules, cylinders, hemispheres, hemicapsules, and rings.",
+          "description": "The radius of the shape or collider. Defaults to 1 meter. Only used by spheres, capsules, cylinders, hemispheres, hemicapsules, and rings.",
           "format": "float"
         },
         "height": {
@@ -5661,7 +5661,7 @@
             "boolean",
             "null"
           ],
-          "description": "Whether to explicitly use a shape instead of a collider. Shapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. \nDefaults to using a shape, unless hasCollision is true where it defaults to using a collider."
+          "description": "Setting this to false will force it to use a collider, and setting to true will force it to use a shape.\nShapes do not support collision and are less performant, but support a wider set of shapes and are required by some components. \nIf left empty it will defaults to using a shape, unless hasCollision is true in which case it defaults to using a collider."
         }
       }
     },

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes

- Change volumes back to using shapes by default (not colliders) else they get disabled when put on held items
- Fixed bug where volume radius gets ignored if you define a sphere shape
