### PR TITLE
Make VanishVolumes never use shapes

### DIFF
--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using static NewHorizons.External.Modules.BrambleModule;
-using static NewHorizons.External.Modules.SignalModule;
 
 namespace NewHorizons.Builder.Props
 {

--- a/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
@@ -1,4 +1,5 @@
 using NewHorizons.External.Modules.Volumes.VolumeInfos;
+using NewHorizons.Utility.OWML;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Volumes
@@ -7,6 +8,17 @@ namespace NewHorizons.Builder.Volumes
     {
         public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VanishVolumeInfo info) where TVolume : VanishVolume
         {
+            if (info.shape != null && (info.shape?.type != External.Modules.Props.ShapeType.Sphere || info.shape?.useShape == false))
+            {
+                NHLogger.LogError($"Destruction/VanishVolumes only support sphere colliders. Affects planet [{planetGO.name}]");
+            }
+
+            // VanishVolume is only compatible with sphere colliders
+            // If info.shape was null, it will still default to using info.radius, just make sure it does so with a collider
+            info.shape ??= new();
+            info.shape.useShape = false;
+            info.shape.type = External.Modules.Props.ShapeType.Sphere;
+
             var volume = VolumeBuilder.Make<TVolume>(planetGO, sector, info);
 
             var collider = volume.gameObject.GetComponent<SphereCollider>();

--- a/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
@@ -8,20 +8,19 @@ namespace NewHorizons.Builder.Volumes
     {
         public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VanishVolumeInfo info) where TVolume : VanishVolume
         {
-            if (info.shape != null && (info.shape?.type != External.Modules.Props.ShapeType.Sphere || info.shape?.useShape == false))
+            if (info.shape != null && info.shape?.useShape == false)
             {
-                NHLogger.LogError($"Destruction/VanishVolumes only support sphere colliders. Affects planet [{planetGO.name}]");
+                NHLogger.LogError($"Destruction/VanishVolumes only support colliders. Affects planet [{planetGO.name}]. Set useShape to false.");
             }
 
             // VanishVolume is only compatible with sphere colliders
-            // If info.shape was null, it will still default to using info.radius, just make sure it does so with a collider
+            // If info.shape was null, it will still default to using a sphere with info.radius, just make sure it does so with a collider
             info.shape ??= new();
             info.shape.useShape = false;
-            info.shape.type = External.Modules.Props.ShapeType.Sphere;
 
             var volume = VolumeBuilder.Make<TVolume>(planetGO, sector, info);
 
-            var collider = volume.gameObject.GetComponent<SphereCollider>();
+            var collider = volume.gameObject.GetComponent<Collider>();
             volume._collider = collider;
             volume._shrinkBodies = info.shrinkBodies;
             volume._onlyAffectsPlayerAndShip = info.onlyAffectsPlayerRelatedBodies;

--- a/NewHorizons/Builder/Volumes/VolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VolumeBuilder.cs
@@ -45,7 +45,7 @@ namespace NewHorizons.Builder.Volumes
             return volume;
         }
 
-        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour //Could be BaseVolume but I need to create vanilla volumes too.
+        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour // Could be BaseVolume but I need to create vanilla volumes too.
         {
             var go = GeneralPropBuilder.MakeNew(typeof(TVolume).Name, planetGO, sector, info);
             return MakeExisting<TVolume>(go, planetGO, sector, info);

--- a/NewHorizons/External/Modules/Volumes/VolumeInfos/VanishVolumeInfo.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumeInfos/VanishVolumeInfo.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 namespace NewHorizons.External.Modules.Volumes.VolumeInfos
 {
     /// <summary>
-    /// Note: Only sphere colliders work on vanish volumes!
+    /// Note: Only colliders work on vanish volumes!
     /// </summary>
     [JsonObject]
     public class VanishVolumeInfo : VolumeInfo

--- a/NewHorizons/External/Modules/Volumes/VolumeInfos/VanishVolumeInfo.cs
+++ b/NewHorizons/External/Modules/Volumes/VolumeInfos/VanishVolumeInfo.cs
@@ -4,6 +4,9 @@ using System.ComponentModel;
 
 namespace NewHorizons.External.Modules.Volumes.VolumeInfos
 {
+    /// <summary>
+    /// Note: Only sphere colliders work on vanish volumes!
+    /// </summary>
     [JsonObject]
     public class VanishVolumeInfo : VolumeInfo
     {

--- a/NewHorizons/manifest.json
+++ b/NewHorizons/manifest.json
@@ -4,7 +4,7 @@
   "author": "xen, Bwc9876, JohnCorby, MegaPiggy, and friends",
   "name": "New Horizons",
   "uniqueName": "xen.NewHorizons",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "owmlVersion": "2.12.1",
   "dependencies": [ "JohnCorby.VanillaFix", "xen.CommonCameraUtility", "dgarro.CustomShipLogModes" ],
   "conflicts": [ "PacificEngine.OW_CommonResources" ],


### PR DESCRIPTION
## Bug fixes

- Fixed a bug where Vanish/DestructionVolumes no longer worked (they were trying to use sphere shapes when they can only use sphere colliders)
