### PR TITLE
unloading streaming stuff in custom systems

### DIFF
--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -47,7 +47,8 @@ namespace NewHorizons.Handlers
             {
                 foreach (var bundle in StreamingManager.s_activeBundles)
                 {
-                    StreamingManager.UnloadStreamingAssets(bundle.assetBundleName);
+                    // save memory NOW instead of next frame when other stuff has loaded and taken memory
+                    bundle.UnloadImmediate();
                 }
             }
             

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -47,8 +47,7 @@ namespace NewHorizons.Handlers
             {
                 foreach (var bundle in StreamingManager.s_activeBundles)
                 {
-                    // save memory NOW instead of next frame when other stuff has loaded and taken memory
-                    bundle.UnloadImmediate();
+                    StreamingManager.UnloadStreamingAssets(bundle.assetBundleName);
                 }
             }
             

--- a/NewHorizons/Handlers/PlanetCreationHandler.cs
+++ b/NewHorizons/Handlers/PlanetCreationHandler.cs
@@ -42,6 +42,15 @@ namespace NewHorizons.Handlers
 
         public static void Init(List<NewHorizonsBody> bodies)
         {
+            // TH gets preloaded in title screen. custom systems dont need this
+            if (Main.Instance.CurrentStarSystem is not ("SolarSystem" or "EyeOfTheUniverse"))
+            {
+                foreach (var bundle in StreamingManager.s_activeBundles)
+                {
+                    StreamingManager.UnloadStreamingAssets(bundle.assetBundleName);
+                }
+            }
+            
             // Start by destroying all planets if need be
             if (Main.SystemDict[Main.Instance.CurrentStarSystem].Config.destroyStockPlanets)
             {


### PR DESCRIPTION
## Improvements

- do not load unnecessary bundles in custom systems. saves VRAM. does not affect RAM

details stay visible
does not seem to cause softlocks.
works when going from custom to regular (you dont fall thru TH)
seems to cause no extra errors in logs