### PR TITLE
Prop Sector Paths

### DIFF
--- a/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
+++ b/NewHorizons/Builder/Body/BrambleDimensionBuilder.cs
@@ -105,7 +105,7 @@ namespace NewHorizons.Builder.Body
                 default: geometryPrefab = _hubGeometry; break;
             }
 
-            var geometry = DetailBuilder.Make(go, sector, mod, geometryPrefab, new DetailInfo());
+            var geometry = DetailBuilder.Make(go, ref sector, mod, geometryPrefab, new DetailInfo());
 
             var exitWarps = _exitWarps.InstantiateInactive();
             var repelVolume = _repelVolume.InstantiateInactive();

--- a/NewHorizons/Builder/Body/ProxyBuilder.cs
+++ b/NewHorizons/Builder/Body/ProxyBuilder.cs
@@ -211,7 +211,8 @@ namespace NewHorizons.Builder.Body
                     foreach (var detailInfo in body.Config.Props.proxyDetails)
                     {
                         // Thought about switching these to SimplifiedDetailInfo but we use AlignRadial with these so we can't
-                        DetailBuilder.Make(proxy, null, body.Mod, detailInfo);
+                        Sector sector = null;
+                        DetailBuilder.Make(proxy, ref sector, body.Mod, detailInfo);
                     }
                 }
 

--- a/NewHorizons/Builder/Body/SingularityBuilder.cs
+++ b/NewHorizons/Builder/Body/SingularityBuilder.cs
@@ -145,7 +145,8 @@ namespace NewHorizons.Builder.Body
                         var sphereCollider = blackHoleVolume.GetComponent<SphereCollider>();
                         // Shouldn't ever be null but doesn't hurt ig
                         var loadRadius = sphereCollider == null ? 100f : sphereCollider.radius + 50f;
-                        var streamingVolume = VolumeBuilder.Make<StreamingWarpVolume>(blackHoleVolume.GetAttachedOWRigidbody().gameObject, blackHoleVolume.GetComponentInParent<Sector>(),
+                        var blackHoleSector = blackHoleVolume.GetComponentInParent<Sector>();
+                        var streamingVolume = VolumeBuilder.Make<StreamingWarpVolume>(blackHoleVolume.GetAttachedOWRigidbody().gameObject, ref blackHoleSector,
                             new External.Modules.Volumes.VolumeInfos.VolumeInfo() { radius = loadRadius });
                         streamingVolume.streamingGroup = streamingGroup;
                         streamingVolume.transform.parent = blackHoleVolume.transform;
@@ -174,7 +175,7 @@ namespace NewHorizons.Builder.Body
                 rename = rename,
             };
 
-            var singularity = GeneralPropBuilder.MakeNew(polarity ? "BlackHole" : "WhiteHole", planetGO, sector, info);
+            var singularity = GeneralPropBuilder.MakeNew(polarity ? "BlackHole" : "WhiteHole", planetGO, ref sector, info);
 
             var singularityRenderer = MakeSingularityGraphics(singularity, polarity, horizon, distort, renderQueue);
 

--- a/NewHorizons/Builder/General/SpawnPointBuilder.cs
+++ b/NewHorizons/Builder/General/SpawnPointBuilder.cs
@@ -39,7 +39,8 @@ namespace NewHorizons.Builder.General
             {
                 foreach (var point in module.playerSpawnPoints)
                 {
-                    GameObject spawnGO = GeneralPropBuilder.MakeNew("PlayerSpawnPoint", planetGO, null, point);
+                    Sector spawnSector = null;
+                    GameObject spawnGO = GeneralPropBuilder.MakeNew("PlayerSpawnPoint", planetGO, ref spawnSector, point);
                     spawnGO.layer = Layer.PlayerSafetyCollider;
 
                     playerSpawn = spawnGO.AddComponent<SpawnPoint>();
@@ -78,7 +79,8 @@ namespace NewHorizons.Builder.General
             {
                 foreach (var point in module.shipSpawnPoints)
                 {
-                    var spawnGO = GeneralPropBuilder.MakeNew("ShipSpawnPoint", planetGO, null, point);
+                    Sector spawnSector = null;
+                    var spawnGO = GeneralPropBuilder.MakeNew("ShipSpawnPoint", planetGO, ref spawnSector, point);
                     spawnGO.layer = Layer.PlayerSafetyCollider;
 
                     var shipSpawn = spawnGO.AddComponent<SpawnPoint>();

--- a/NewHorizons/Builder/Props/Audio/GeneralAudioBuilder.cs
+++ b/NewHorizons/Builder/Props/Audio/GeneralAudioBuilder.cs
@@ -19,7 +19,7 @@ namespace NewHorizons.Builder.Props.Audio
 
         public static OWAudioSource Make(GameObject planetGO, Sector sector, BaseAudioInfo info, IModBehaviour mod)
         {
-            var signalGO = GeneralPropBuilder.MakeNew($"{(string.IsNullOrEmpty(info.rename) ? "AudioSource" : info.rename)}", planetGO, sector, info);
+            var signalGO = GeneralPropBuilder.MakeNew($"{(string.IsNullOrEmpty(info.rename) ? "AudioSource" : info.rename)}", planetGO, ref sector, info);
             signalGO.layer = Layer.AdvancedEffectVolume;
 
             var source = signalGO.AddComponent<AudioSource>();

--- a/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
+++ b/NewHorizons/Builder/Props/BrambleNodeBuilder.cs
@@ -194,7 +194,7 @@ namespace NewHorizons.Builder.Props
             var prefab = config.isSeed ? _brambleSeedPrefab : _brambleNodePrefab;
 
             // Spawn the bramble node
-            var brambleNode = GeneralPropBuilder.MakeFromPrefab(prefab, config.name ?? "Bramble Node to " + config.linksTo, go, sector, config);
+            var brambleNode = GeneralPropBuilder.MakeFromPrefab(prefab, config.name ?? "Bramble Node to " + config.linksTo, go, ref sector, config);
             foreach (var collider in brambleNode.GetComponentsInChildren<Collider>(true))
             {
                 collider.enabled = true; 
@@ -428,6 +428,7 @@ namespace NewHorizons.Builder.Props
                     var signalConfigCopy = JsonConvert.DeserializeObject<SignalInfo>(JsonConvert.SerializeObject(signalConfig));
                     signalConfigCopy.parentPath = null;
                     signalConfigCopy.isRelativeToParent = false;
+                    signalConfigCopy.sectorPath = null;
 
                     var signalGO = SignalBuilder.Make(go, sector, signalConfigCopy, mod);
                     signalGO.GetComponent<AudioSignal>()._identificationDistance = 0;

--- a/NewHorizons/Builder/Props/DialogueBuilder.cs
+++ b/NewHorizons/Builder/Props/DialogueBuilder.cs
@@ -246,7 +246,7 @@ namespace NewHorizons.Builder.Props
 
         private static RemoteDialogueTrigger MakeRemoteDialogueTrigger(GameObject planetGO, Sector sector, DialogueInfo info, CharacterDialogueTree dialogue)
         {
-            var conversationTrigger = GeneralPropBuilder.MakeNew("ConversationTrigger", planetGO, sector, info.remoteTrigger, defaultPosition: info.position, defaultParentPath: info.pathToAnimController);
+            var conversationTrigger = GeneralPropBuilder.MakeNew("ConversationTrigger", planetGO, ref sector, info.remoteTrigger, defaultPosition: info.position, defaultParentPath: info.pathToAnimController);
 
             var remoteDialogueTrigger = conversationTrigger.AddComponent<RemoteDialogueTrigger>();
             var sphereCollider = conversationTrigger.AddComponent<SphereCollider>();
@@ -277,7 +277,7 @@ namespace NewHorizons.Builder.Props
 
         private static CharacterDialogueTree MakeConversationZone(GameObject planetGO, Sector sector, DialogueInfo info, string xml, string dialogueName)
         {
-            var conversationZone = GeneralPropBuilder.MakeNew("ConversationZone", planetGO, sector, info, defaultParentPath: info.pathToAnimController);
+            var conversationZone = GeneralPropBuilder.MakeNew("ConversationZone", planetGO, ref sector, info, defaultParentPath: info.pathToAnimController);
 
             conversationZone.layer = Layer.Interactible;
 
@@ -345,7 +345,8 @@ namespace NewHorizons.Builder.Props
         {
             if (info.attentionPoint != null)
             {
-                var ptGo = GeneralPropBuilder.MakeNew("AttentionPoint", go, sector, info.attentionPoint, defaultParent: dialogue.transform);
+                var pointSector = sector;
+                var ptGo = GeneralPropBuilder.MakeNew("AttentionPoint", go, ref pointSector, info.attentionPoint, defaultParent: dialogue.transform);
                 dialogue._attentionPoint = ptGo.transform;
                 dialogue._attentionPointOffset = info.attentionPoint.offset ?? Vector3.zero;
                 ptGo.SetActive(true);
@@ -354,7 +355,8 @@ namespace NewHorizons.Builder.Props
             {
                 foreach (var pointInfo in info.swappedAttentionPoints)
                 {
-                    var ptGo = GeneralPropBuilder.MakeNew($"AttentionPoint_{pointInfo.dialogueNode}_{pointInfo.dialoguePage}", go, sector, pointInfo, defaultParent: dialogue.transform);
+                    var pointSector = sector;
+                    var ptGo = GeneralPropBuilder.MakeNew($"AttentionPoint_{pointInfo.dialogueNode}_{pointInfo.dialoguePage}", go, ref pointSector, pointInfo, defaultParent: dialogue.transform);
                     var swapper = ptGo.AddComponent<DialogueAttentionPointSwapper>();
                     swapper._dialogueTree = dialogue;
                     swapper._attentionPoint = ptGo.transform;

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/AlarmTotemBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/AlarmTotemBuilder.cs
@@ -42,7 +42,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var totemObj = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var totemObj = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             var alarmTotem = totemObj.GetComponent<AlarmTotem>();
             alarmTotem._sightAngle = info.sightAngle;

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/DreamArrivalPointBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/DreamArrivalPointBuilder.cs
@@ -48,7 +48,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var arrivalPointObj = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var arrivalPointObj = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             StreamingHandler.SetUpStreaming(arrivalPointObj, sector);
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/DreamCampfireBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/DreamCampfireBuilder.cs
@@ -44,7 +44,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var campfireObj = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var campfireObj = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             var campfire = campfireObj.GetComponentInChildren<DreamCampfire>();
             campfire._dreamArrivalLocation = DreamHandler.GetDreamArrivalLocation(info.id);

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/DreamCandleBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/DreamCandleBuilder.cs
@@ -60,7 +60,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (prefab == null || sector == null) return null;
 
-            var candleObj = DetailBuilder.Make(planetGO, sector, mod, prefab, new DetailInfo(info));
+            var candleObj = DetailBuilder.Make(planetGO, ref sector, mod, prefab, new DetailInfo(info));
 
             var dreamCandle = candleObj.GetComponent<DreamCandle>();
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/GrappleTotemBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/GrappleTotemBuilder.cs
@@ -44,7 +44,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var totemObj = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var totemObj = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             var zoomPoint = totemObj.GetComponentInChildren<LanternZoomPoint>();
             zoomPoint._minActivationDistance = info.minDistance;

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/PortholeBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/PortholeBuilder.cs
@@ -57,13 +57,15 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_mainPrefab == null || _simPrefab == null || sector == null) return null;
 
-            var portholeObj = DetailBuilder.Make(planetGO, sector, mod, _mainPrefab, new DetailInfo(info));
+            var portholeSector = sector;
+            var portholeObj = DetailBuilder.Make(planetGO, ref portholeSector, mod, _mainPrefab, new DetailInfo(info));
             portholeObj.name = "Prefab_Porthole";
 
-            var simObj = DetailBuilder.Make(planetGO, sector, mod, _simPrefab, new DetailInfo(info));
+            var simSector = sector;
+            var simObj = DetailBuilder.Make(planetGO, ref simSector, mod, _simPrefab, new DetailInfo(info));
             simObj.transform.parent = portholeObj.transform;
 
-            var parentObj = GeneralPropBuilder.MakeNew("Porthole", planetGO, sector, info);
+            var parentObj = GeneralPropBuilder.MakeNew("Porthole", planetGO, ref sector, info);
             parentObj.SetActive(true);
             portholeObj.transform.SetParent(parentObj.transform, true);
             portholeObj.transform.localPosition = new Vector3(0f, -4f, 8f);
@@ -81,10 +83,14 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
             // Reposition the peephole camera later, after all planets are built, in case the target point is on a different astro body.
             Delay.FireInNUpdates(() =>
             {
-                var cameraObj = GeneralPropBuilder.MakeFromExisting(peephole._peepholeCamera.gameObject, planetGO, sector, info.target);
+                var viewingSector = sector;
+                if (string.IsNullOrEmpty(info.target.sectorPath))
+                {
+                    info.target.sectorPath = "auto";
+                }
+                var cameraObj = GeneralPropBuilder.MakeFromExisting(peephole._peepholeCamera.gameObject, planetGO, ref viewingSector, info.target);
                 cameraObj.transform.Rotate(Vector3.up, 180f, Space.Self);
                 cameraObj.transform.position += cameraObj.transform.up;
-                var viewingSector = cameraObj.GetComponentInParent<Sector>();
                 peephole._viewingSector = viewingSector;
             }, 2);
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/ProjectionTotemBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/ProjectionTotemBuilder.cs
@@ -44,7 +44,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var totemObj = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var totemObj = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             var projector = totemObj.GetComponent<DreamObjectProjector>();
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftBuilder.cs
@@ -119,7 +119,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || _cleanPrefab == null || sector == null) return null;
 
-            GameObject raftObject = GeneralPropBuilder.MakeFromPrefab(info.pristine ? _cleanPrefab : _prefab, "Raft_Body", planetGO, sector, info);
+            GameObject raftObject = GeneralPropBuilder.MakeFromPrefab(info.pristine ? _cleanPrefab : _prefab, "Raft_Body", planetGO, ref sector, info);
 
             StreamingHandler.SetUpStreaming(raftObject, sector);
 

--- a/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
+++ b/NewHorizons/Builder/Props/EchoesOfTheEye/RaftDockBuilder.cs
@@ -45,7 +45,7 @@ namespace NewHorizons.Builder.Props.EchoesOfTheEye
 
             if (_prefab == null || sector == null) return null;
 
-            var dockObject = DetailBuilder.Make(planetGO, sector, mod, _prefab, new DetailInfo(info));
+            var dockObject = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, new DetailInfo(info));
 
             //var raftDock = dockObject.GetComponent<RaftDock>();
 

--- a/NewHorizons/Builder/Props/EyeOfTheUniverseBuilder.cs
+++ b/NewHorizons/Builder/Props/EyeOfTheUniverseBuilder.cs
@@ -16,6 +16,8 @@ namespace NewHorizons.Builder.Props
     {
         public static TravelerEyeController MakeEyeTraveler(GameObject planetGO, Sector sector, EyeTravelerInfo info, NewHorizonsBody nhBody)
         {
+            var planetSector = sector;
+
             var travelerData = EyeSceneHandler.CreateEyeTravelerData(info.id);
             travelerData.info = info;
             travelerData.requirementsMet = true;
@@ -35,7 +37,7 @@ namespace NewHorizons.Builder.Props
                 return null;
             }
 
-            var go = DetailBuilder.Make(planetGO, sector, nhBody.Mod, info);
+            var go = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, info);
 
             var travelerController = go.GetAddComponent<TravelerEyeController>();
             if (!string.IsNullOrEmpty(info.startPlayingCondition))
@@ -57,7 +59,8 @@ namespace NewHorizons.Builder.Props
                 {
                     info.dialogue.isRelativeToParent = true;
                 }
-                GeneralPropBuilder.MakeFromExisting(dialogueTree.gameObject, planetGO, sector, info.dialogue, defaultParent: go.transform);
+                var dialogueSector = planetSector;
+                GeneralPropBuilder.MakeFromExisting(dialogueTree.gameObject, planetGO, ref dialogueSector, info.dialogue, defaultParent: go.transform);
 
                 if (travelerController._dialogueTree != null)
                 {
@@ -96,7 +99,8 @@ namespace NewHorizons.Builder.Props
                 {
                     info.signal.isRelativeToParent = true;
                 }
-                GeneralPropBuilder.MakeFromExisting(signalGO, planetGO, sector, info.signal, defaultParent: go.transform);
+                var signalSector = planetSector;
+                GeneralPropBuilder.MakeFromExisting(signalGO, planetGO, ref signalSector, info.signal, defaultParent: go.transform);
 
                 var signal = signalGO.GetComponent<AudioSignal>();
                 travelerController._signal = signal;
@@ -136,6 +140,8 @@ namespace NewHorizons.Builder.Props
 
         public static QuantumInstrument MakeQuantumInstrument(GameObject planetGO, Sector sector, QuantumInstrumentInfo info, NewHorizonsBody nhBody)
         {
+            var planetSector = sector;
+
             var travelerData = EyeSceneHandler.GetEyeTravelerData(info.id);
 
             if (travelerData != null && !travelerData.requirementsMet)
@@ -143,7 +149,7 @@ namespace NewHorizons.Builder.Props
                 return null;
             }
 
-            var go = DetailBuilder.Make(planetGO, sector, nhBody.Mod, info);
+            var go = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, info);
             go.layer = Layer.Interactible;
             if (info.interactRadius > 0f)
             {
@@ -190,12 +196,13 @@ namespace NewHorizons.Builder.Props
 
             if (!string.IsNullOrEmpty(info.signal.audio))
             {
-                var signalGO = SignalBuilder.Make(planetGO, sector, info.signal, nhBody.Mod);
+                var signalSector = planetSector;
+                var signalGO = SignalBuilder.Make(planetGO, signalSector, info.signal, nhBody.Mod);
                 if (info.signal.position == null && info.signal.parentPath == null)
                 {
                     info.signal.isRelativeToParent = true;
                 }
-                GeneralPropBuilder.MakeFromExisting(signalGO, planetGO, sector, info.signal, defaultParent: go.transform);
+                GeneralPropBuilder.MakeFromExisting(signalGO, planetGO, ref signalSector, info.signal, defaultParent: go.transform);
             }
             else
             {
@@ -214,7 +221,7 @@ namespace NewHorizons.Builder.Props
                 return null;
             }
 
-            var go = DetailBuilder.Make(planetGO, sector, nhBody.Mod, info);
+            var go = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, info);
 
             var instrumentZone = go.AddComponent<InstrumentZone>();
 

--- a/NewHorizons/Builder/Props/GeyserBuilder.cs
+++ b/NewHorizons/Builder/Props/GeyserBuilder.cs
@@ -18,7 +18,7 @@ namespace NewHorizons.Builder.Props
         {
             InitPrefab();
 
-            var geyserGO = GeneralPropBuilder.MakeFromPrefab(_geyserPrefab, "Geyser", planetGO, sector, info);
+            var geyserGO = GeneralPropBuilder.MakeFromPrefab(_geyserPrefab, "Geyser", planetGO, ref sector, info);
 
             geyserGO.transform.position += geyserGO.transform.up * info.offset;
 

--- a/NewHorizons/Builder/Props/GravityCannonBuilder.cs
+++ b/NewHorizons/Builder/Props/GravityCannonBuilder.cs
@@ -66,7 +66,8 @@ namespace NewHorizons.Builder.Props
             if (_interfacePrefab == null || planetGO == null || sector == null || _detailedPlatformPrefab == null || _platformPrefab == null) return null;
 
             var detailInfo = new DetailInfo(info.controls) { keepLoaded = true };
-            var gravityCannonObject = DetailBuilder.Make(planetGO, sector, mod, _interfacePrefab, detailInfo);
+            var cannonSector = sector;
+            var gravityCannonObject = DetailBuilder.Make(planetGO, ref cannonSector, mod, _interfacePrefab, detailInfo);
             gravityCannonObject.SetActive(false);
 
             var gravityCannonController = gravityCannonObject.GetComponent<GravityCannonController>();
@@ -122,7 +123,7 @@ namespace NewHorizons.Builder.Props
 
         private static GameObject CreatePlatform(GameObject planetGO, Sector sector, IModBehaviour mod, GravityCannonController gravityCannonController, GravityCannonInfo platformInfo)
         {
-            var platform = DetailBuilder.Make(planetGO, sector, mod, platformInfo.detailed ? _detailedPlatformPrefab : _platformPrefab, new DetailInfo(platformInfo) { keepLoaded = true });
+            var platform = DetailBuilder.Make(planetGO, ref sector, mod, platformInfo.detailed ? _detailedPlatformPrefab : _platformPrefab, new DetailInfo(platformInfo) { keepLoaded = true });
 
             gravityCannonController._forceVolume = platform.FindChild("ForceVolume").GetComponent<DirectionalForceVolume>();
             gravityCannonController._platformTrigger = platform.FindChild("PlatformTrigger").GetComponent<OWTriggerVolume>();

--- a/NewHorizons/Builder/Props/ItemBuilder.cs
+++ b/NewHorizons/Builder/Props/ItemBuilder.cs
@@ -147,7 +147,8 @@ namespace NewHorizons.Builder.Props
             }
             if (socket._socketTransform == null)
             {
-                var socketGO = GeneralPropBuilder.MakeNew("Socket", planetGO, sector, info, defaultParent: go.transform);
+                var socketSector = sector;
+                var socketGO = GeneralPropBuilder.MakeNew("Socket", planetGO, ref socketSector, info, defaultParent: go.transform);
                 socketGO.SetActive(true);
                 socket._socketTransform = socketGO.transform;
             }

--- a/NewHorizons/Builder/Props/ProjectionBuilder.cs
+++ b/NewHorizons/Builder/Props/ProjectionBuilder.cs
@@ -148,7 +148,7 @@ namespace NewHorizons.Builder.Props
 
             if (prefab == null) return null;
 
-            var slideReelObj = GeneralPropBuilder.MakeFromPrefab(prefab, $"Prefab_IP_Reel_{GetSlideReelName(info.reelModel, info.reelCondition)}_{mod.ModHelper.Manifest.Name}", planetGO, sector, info);
+            var slideReelObj = GeneralPropBuilder.MakeFromPrefab(prefab, $"Prefab_IP_Reel_{GetSlideReelName(info.reelModel, info.reelCondition)}_{mod.ModHelper.Manifest.Name}", planetGO, ref sector, info);
 
             var slideReel = slideReelObj.GetComponent<SlideReelItem>();
             slideReel.SetSector(sector);
@@ -358,7 +358,7 @@ namespace NewHorizons.Builder.Props
 
             if (_autoPrefab == null) return null;
 
-            var projectorObj = GeneralPropBuilder.MakeFromPrefab(_autoPrefab, $"Prefab_IP_AutoProjector_{mod.ModHelper.Manifest.Name}", planetGO, sector, info);
+            var projectorObj = GeneralPropBuilder.MakeFromPrefab(_autoPrefab, $"Prefab_IP_AutoProjector_{mod.ModHelper.Manifest.Name}", planetGO, ref sector, info);
 
             var autoProjector = projectorObj.GetComponent<AutoSlideProjector>();
             autoProjector._sector = sector;
@@ -421,7 +421,7 @@ namespace NewHorizons.Builder.Props
             if (_visionTorchDetectorPrefab == null) return null;
 
             // spawn a trigger for the vision torch
-            var visionTorchTargetGO = DetailBuilder.Make(planetGO, sector, mod, _visionTorchDetectorPrefab, new DetailInfo(info) { scale = 2, rename = !string.IsNullOrEmpty(info.rename) ? info.rename : "VisionStaffDetector" });
+            var visionTorchTargetGO = DetailBuilder.Make(planetGO, ref sector, mod, _visionTorchDetectorPrefab, new DetailInfo(info) { scale = 2, rename = !string.IsNullOrEmpty(info.rename) ? info.rename : "VisionStaffDetector" });
 
             if (visionTorchTargetGO == null)
             {
@@ -466,7 +466,7 @@ namespace NewHorizons.Builder.Props
 
             // Spawn the torch itself
             var prefab = info.reelCondition == ProjectionInfo.SlideReelCondition.Pristine ? _standingVisionTorchCleanPrefab : _standingVisionTorchPrefab;
-            var standingTorch = DetailBuilder.Make(planetGO, sector, mod, prefab, new DetailInfo(info));
+            var standingTorch = DetailBuilder.Make(planetGO, ref sector, mod, prefab, new DetailInfo(info));
 
             if (standingTorch == null)
             {

--- a/NewHorizons/Builder/Props/QuantumBuilder.cs
+++ b/NewHorizons/Builder/Props/QuantumBuilder.cs
@@ -41,9 +41,13 @@ namespace NewHorizons.Builder.Props
 
         public static void MakeQuantumLightning(GameObject planetGO, Sector sector, IModBehaviour mod, LightningQuantumInfo quantumGroup)
         {
-            (GameObject go, DetailInfo detail)[] propsInGroup = quantumGroup.details.Select(x => (DetailBuilder.Make(planetGO, sector, mod, x), x)).ToArray();
+            (GameObject go, DetailInfo detail)[] propsInGroup = quantumGroup.details.Select(info => {
+                var propSector = sector;
+                var prop = DetailBuilder.Make(planetGO, ref propSector, mod, info);
+                return (prop, info);
+            }).ToArray();
 
-            var lightning = DetailBuilder.Make(planetGO, sector, Main.Instance, AssetBundleUtilities.NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_EYE_QuantumLightningObject"), new DetailInfo(quantumGroup));
+            var lightning = DetailBuilder.Make(planetGO, ref sector, Main.Instance, AssetBundleUtilities.NHPrivateAssetBundle.LoadAsset<GameObject>("Prefab_EYE_QuantumLightningObject"), new DetailInfo(quantumGroup));
             AssetBundleUtilities.ReplaceShaders(lightning);
 
             foreach (var (go, _) in propsInGroup)
@@ -95,7 +99,7 @@ namespace NewHorizons.Builder.Props
             {
                 var socketInfo = quantumGroup.sockets[i];
 
-                var socket = GeneralPropBuilder.MakeNew("Socket " + i, planetGO, sector, socketInfo, defaultParent: groupRoot.transform);
+                var socket = GeneralPropBuilder.MakeNew("Socket " + i, planetGO, ref sector, socketInfo, defaultParent: groupRoot.transform);
 
                 sockets[i] = socket.AddComponent<QuantumSocket>();
                 sockets[i]._lightSources = new Light[0]; // TODO: make this customizable?
@@ -126,8 +130,9 @@ namespace NewHorizons.Builder.Props
                 // Can't have 4 objects in 4 slots
                 // Instead we have a duplicate of the final object for each slot, which appears when that slot is "empty"
                 for (int i = 0; i < sockets.Length; i++)
-                {                    
-                    var emptySocketObject = DetailBuilder.Make(planetGO, sector, mod, new DetailInfo(specialInfo));
+                {
+                    var socketSector = sector;
+                    var emptySocketObject = DetailBuilder.Make(planetGO, ref socketSector, mod, new DetailInfo(specialInfo));
                     var socket = sockets[i];
                     socket._emptySocketObject = emptySocketObject;
                     emptySocketObject.SetActive(socket._quantumObject == null);

--- a/NewHorizons/Builder/Props/RemoteBuilder.cs
+++ b/NewHorizons/Builder/Props/RemoteBuilder.cs
@@ -204,7 +204,7 @@ namespace NewHorizons.Builder.Props
         {
             InitPrefabs();
             var mod = nhBody.Mod;
-            var whiteboard = DetailBuilder.Make(go, sector, mod, _whiteboardPrefab, new DetailInfo(info));
+            var whiteboard = DetailBuilder.Make(go, ref sector, mod, _whiteboardPrefab, new DetailInfo(info));
             whiteboard.SetActive(false);
 
             var decalMat = new Material(_decalMaterial);
@@ -245,7 +245,7 @@ namespace NewHorizons.Builder.Props
         public static void MakePlatform(GameObject go, Sector sector, NomaiRemoteCameraPlatform.ID id, Texture2D decal, RemotePlatformInfo info, IModBehaviour mod)
         {
             InitPrefabs();
-            var platform = DetailBuilder.Make(go, sector, mod, _remoteCameraPlatformPrefab, new DetailInfo(info));
+            var platform = DetailBuilder.Make(go, ref sector, mod, _remoteCameraPlatformPrefab, new DetailInfo(info));
             platform.SetActive(false);
 
             var decalMat = new Material(_decalMaterial);
@@ -272,7 +272,7 @@ namespace NewHorizons.Builder.Props
         public static void MakeStone(GameObject go, Sector sector, NomaiRemoteCameraPlatform.ID id, Texture2D decal, ProjectionStoneInfo info, IModBehaviour mod)
         {
             InitPrefabs();
-            var shareStone = GeneralPropBuilder.MakeFromPrefab(_shareStonePrefab, "ShareStone_" + id.ToString(), go, sector, info);
+            var shareStone = GeneralPropBuilder.MakeFromPrefab(_shareStonePrefab, "ShareStone_" + id.ToString(), go, ref sector, info);
 
             shareStone.GetComponent<SharedStone>()._connectedPlatform = id;
 

--- a/NewHorizons/Builder/Props/ScatterBuilder.cs
+++ b/NewHorizons/Builder/Props/ScatterBuilder.cs
@@ -76,9 +76,9 @@ namespace NewHorizons.Builder.Props
                 {
                     scale = propInfo.scale,
                     stretch = propInfo.stretch,
-					keepLoaded = propInfo.keepLoaded
+					keepLoaded = propInfo.keepLoaded,
                 };
-                var scatterPrefab = DetailBuilder.Make(go, sector, mod, prefab, detailInfo);
+                var scatterPrefab = DetailBuilder.Make(go, ref sector, mod, prefab, detailInfo);
 
                 for (int i = 0; i < propInfo.count; i++)
                 {

--- a/NewHorizons/Builder/Props/ShuttleBuilder.cs
+++ b/NewHorizons/Builder/Props/ShuttleBuilder.cs
@@ -76,7 +76,7 @@ namespace NewHorizons.Builder.Props
             if (_prefab == null || planetGO == null || sector == null) return null;
 
             var detailInfo = new DetailInfo(info) { keepLoaded = true };
-            var shuttleObject = DetailBuilder.Make(planetGO, sector, mod, _prefab, detailInfo);
+            var shuttleObject = DetailBuilder.Make(planetGO, ref sector, mod, _prefab, detailInfo);
             shuttleObject.SetActive(false);
 
             StreamingHandler.SetUpStreaming(shuttleObject, sector);

--- a/NewHorizons/Builder/Props/TornadoBuilder.cs
+++ b/NewHorizons/Builder/Props/TornadoBuilder.cs
@@ -101,7 +101,7 @@ namespace NewHorizons.Builder.Props
         private static void MakeTornado(GameObject planetGO, Sector sector, TornadoInfo info, Vector3 position, bool downwards)
         {
             var prefab = downwards ? _downPrefab.InstantiateInactive() : _upPrefab.InstantiateInactive();
-            var tornadoGO = GeneralPropBuilder.MakeFromPrefab(prefab, downwards ? "Tornado_Down" : "Tornado_Up", planetGO, sector, info, defaultPosition: position);
+            var tornadoGO = GeneralPropBuilder.MakeFromPrefab(prefab, downwards ? "Tornado_Down" : "Tornado_Up", planetGO, ref sector, info, defaultPosition: position);
 
             // Add the sound thing before changing the scale
             var soundGO = _soundPrefab.InstantiateInactive();

--- a/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
+++ b/NewHorizons/Builder/Props/TranslatorText/TranslatorTextBuilder.cs
@@ -146,7 +146,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                 case NomaiTextType.Wall:
                     {
                         var nomaiWallTextObj = MakeWallText(planetGO, sector, info, xmlContent, nhBody).gameObject;
-                        nomaiWallTextObj = GeneralPropBuilder.MakeFromExisting(nomaiWallTextObj, planetGO, sector, info);
+                        nomaiWallTextObj = GeneralPropBuilder.MakeFromExisting(nomaiWallTextObj, planetGO, ref sector, info);
 
                         if (info.normal != null)
                         {
@@ -169,7 +169,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                     }
                 case NomaiTextType.Scroll:
                     {
-                        var customScroll = GeneralPropBuilder.MakeFromPrefab(_scrollPrefab, _scrollPrefab.name, planetGO, sector, info);
+                        var customScroll = GeneralPropBuilder.MakeFromPrefab(_scrollPrefab, _scrollPrefab.name, planetGO, ref sector, info);
 
                         var nomaiWallText = MakeWallText(planetGO, sector, info, xmlContent, nhBody);
                         nomaiWallText.transform.parent = customScroll.transform;
@@ -221,7 +221,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                     }
                 case NomaiTextType.Computer:
                     {
-                        var computerObject = GeneralPropBuilder.MakeFromPrefab(ComputerPrefab, ComputerPrefab.name, planetGO, sector, info);
+                        var computerObject = GeneralPropBuilder.MakeFromPrefab(ComputerPrefab, ComputerPrefab.name, planetGO, ref sector, info);
 
                         var computer = computerObject.GetComponent<NomaiComputer>();
                         computer.SetSector(sector);
@@ -242,7 +242,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                     }
                 case NomaiTextType.PreCrashComputer:
                     {
-                        var computerObject = DetailBuilder.Make(planetGO, sector, nhBody.Mod, PreCrashComputerPrefab, new DetailInfo(info));
+                        var computerObject = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, PreCrashComputerPrefab, new DetailInfo(info));
                         computerObject.SetActive(false);
 
                         var computer = computerObject.GetComponent<NomaiVesselComputer>();
@@ -284,7 +284,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                 case NomaiTextType.CairnEmberTwin:
                     {
                         var cairnPrefab = info.type == NomaiTextType.CairnTimberHearth ? _cairnTHPrefab : (info.type == NomaiTextType.CairnEmberTwin ? _cairnCTPrefab : _cairnBHPrefab);
-                        var cairnObject = GeneralPropBuilder.MakeFromPrefab(cairnPrefab, cairnPrefab.name, planetGO, sector, info);
+                        var cairnObject = GeneralPropBuilder.MakeFromPrefab(cairnPrefab, cairnPrefab.name, planetGO, ref sector, info);
 
                         // Idk do we have to set it active before finding things?
                         cairnObject.SetActive(true);
@@ -323,7 +323,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                 case NomaiTextType.Recorder:
                     {
                         var prefab = (info.type == NomaiTextType.PreCrashRecorder ? _preCrashRecorderPrefab : _recorderPrefab);
-                        var recorderObject = DetailBuilder.Make(planetGO, sector, nhBody.Mod, prefab, new DetailInfo(info));
+                        var recorderObject = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, prefab, new DetailInfo(info));
                         recorderObject.SetActive(false);
 
                         var nomaiText = recorderObject.GetComponentInChildren<NomaiText>();
@@ -343,7 +343,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                     }
                 case NomaiTextType.Trailmarker:
                     {
-                        var trailmarkerObject = GeneralPropBuilder.MakeFromPrefab(_trailmarkerPrefab, _trailmarkerPrefab.name, planetGO, sector, info);
+                        var trailmarkerObject = GeneralPropBuilder.MakeFromPrefab(_trailmarkerPrefab, _trailmarkerPrefab.name, planetGO, ref sector, info);
 
                         // shrink because that is what mobius does on all trailmarkers or else they are the size of the player
                         trailmarkerObject.transform.localScale = Vector3.one * 0.75f;
@@ -373,7 +373,7 @@ namespace NewHorizons.Builder.Props.TranslatorText
                             path = "BrittleHollow_Body/Sector_BH/Sector_NorthHemisphere/Sector_NorthPole/Sector_HangingCity/Sector_HangingCity_District2/Interactables_HangingCity_District2/VisibleFrom_HangingCity/Props_NOM_Whiteboard (1)",
                             rename = info.rename ?? "Props_NOM_Whiteboard",
                         };
-                        var whiteboardObject = DetailBuilder.Make(planetGO, sector, nhBody.Mod, whiteboardInfo);
+                        var whiteboardObject = DetailBuilder.Make(planetGO, ref sector, nhBody.Mod, whiteboardInfo);
 
                         // Spawn a scroll and insert it into the whiteboard, but only if text is provided
                         if (!string.IsNullOrEmpty(info.xmlFile))

--- a/NewHorizons/Builder/Props/VolcanoBuilder.cs
+++ b/NewHorizons/Builder/Props/VolcanoBuilder.cs
@@ -45,7 +45,7 @@ namespace NewHorizons.Builder.Props
         {
             InitPrefab();
 
-            var launcherGO = GeneralPropBuilder.MakeFromPrefab(_meteorLauncherPrefab, "MeteorLauncher", planetGO, sector, info);
+            var launcherGO = GeneralPropBuilder.MakeFromPrefab(_meteorLauncherPrefab, "MeteorLauncher", planetGO, ref sector, info);
 
             var meteorLauncher = launcherGO.GetComponent<MeteorLauncher>();
             meteorLauncher._audioSector = sector;

--- a/NewHorizons/Builder/Props/WarpPadBuilder.cs
+++ b/NewHorizons/Builder/Props/WarpPadBuilder.cs
@@ -93,7 +93,8 @@ namespace NewHorizons.Builder.Props
         public static void Make(GameObject planetGO, Sector sector, IModBehaviour mod, NomaiWarpReceiverInfo info)
         {
             var detailInfo = new DetailInfo(info);
-            var receiverObject = DetailBuilder.Make(planetGO, sector, mod, info.detailed ? _detailedReceiverPrefab : _receiverPrefab, detailInfo);
+            var receiverSector = sector;
+            var receiverObject = DetailBuilder.Make(planetGO, ref receiverSector, mod, info.detailed ? _detailedReceiverPrefab : _receiverPrefab, detailInfo);
 
             NHLogger.Log($"Position is {detailInfo.position} was {info.position}");
 
@@ -132,7 +133,7 @@ namespace NewHorizons.Builder.Props
 
         public static void Make(GameObject planetGO, Sector sector, IModBehaviour mod, NomaiWarpTransmitterInfo info)
         {
-            var transmitterObject = DetailBuilder.Make(planetGO, sector, mod, _transmitterPrefab, new DetailInfo(info));
+            var transmitterObject = DetailBuilder.Make(planetGO, ref sector, mod, _transmitterPrefab, new DetailInfo(info));
 
             var transmitter = transmitterObject.GetComponentInChildren<NomaiWarpTransmitter>();
             transmitter._frequency = GetFrequency(info.frequency);
@@ -151,7 +152,7 @@ namespace NewHorizons.Builder.Props
 
         private static void CreateComputer(GameObject planetGO, Sector sector, IModBehaviour mod, GeneralPropInfo computerInfo, NomaiWarpReceiver receiver)
         {
-            var computerObject = DetailBuilder.Make(planetGO, sector, mod, TranslatorTextBuilder.ComputerPrefab, new DetailInfo(computerInfo));
+            var computerObject = DetailBuilder.Make(planetGO, ref sector, mod, TranslatorTextBuilder.ComputerPrefab, new DetailInfo(computerInfo));
 
             var computer = computerObject.GetComponentInChildren<NomaiComputer>();
             computer.SetSector(sector);

--- a/NewHorizons/Builder/ShipLog/EntryLocationBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/EntryLocationBuilder.cs
@@ -11,7 +11,7 @@ namespace NewHorizons.Builder.ShipLog
         private static readonly List<ShipLogEntryLocation> _locationsToInitialize = new List<ShipLogEntryLocation>();
         public static void Make(GameObject go, Sector sector, EntryLocationInfo info, IModBehaviour mod)
         {
-            GameObject entryLocationGameObject = GeneralPropBuilder.MakeNew("Entry Location (" + info.id + ")", go, sector, info);
+            GameObject entryLocationGameObject = GeneralPropBuilder.MakeNew("Entry Location (" + info.id + ")", go, ref sector, info);
 
             ShipLogEntryLocation newLocation = entryLocationGameObject.AddComponent<ShipLogEntryLocation>();
             newLocation._entryID = info.id;

--- a/NewHorizons/Builder/ShipLog/RevealBuilder.cs
+++ b/NewHorizons/Builder/ShipLog/RevealBuilder.cs
@@ -12,7 +12,7 @@ namespace NewHorizons.Builder.ShipLog
     {
         public static void Make(GameObject go, Sector sector, RevealVolumeInfo info, IModBehaviour mod)
         {
-            var newRevealGO = GeneralPropBuilder.MakeNew("Reveal Volume (" + info.revealOn + ")", go, sector, info);
+            var newRevealGO = GeneralPropBuilder.MakeNew("Reveal Volume (" + info.revealOn + ")", go, ref sector, info);
             switch (info.revealOn)
             {
                 case RevealVolumeInfo.RevealVolumeType.Enter:

--- a/NewHorizons/Builder/Volumes/AudioVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/AudioVolumeBuilder.cs
@@ -12,7 +12,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static AudioVolume Make(GameObject planetGO, Sector sector, AudioVolumeInfo info, IModBehaviour mod)
         {
-            var go = GeneralPropBuilder.MakeNew("AudioVolume", planetGO, sector, info);
+            var go = GeneralPropBuilder.MakeNew("AudioVolume", planetGO, ref sector, info);
             go.layer = Layer.AdvancedEffectVolume;
 
             var audioSource = go.AddComponent<AudioSource>();
@@ -25,7 +25,7 @@ namespace NewHorizons.Builder.Volumes
             owAudioSource.SetTrack(info.track.ConvertToOW());
             AudioUtilities.SetAudioClip(owAudioSource, info.audio, mod);
 
-            var audioVolume = PriorityVolumeBuilder.MakeExisting<AudioVolume>(go, planetGO, sector, info);
+            var audioVolume = PriorityVolumeBuilder.MakeExisting<AudioVolume>(go, planetGO, ref sector, info);
 
             audioVolume._layer = info.layer;
             audioVolume.SetPriority(info.priority);

--- a/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ChangeStarSystemVolumeBuilder.cs
@@ -8,7 +8,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static WarpVolume Make(GameObject planetGO, Sector sector, ChangeStarSystemVolumeInfo info)
         {
-            var volume = VolumeBuilder.Make<WarpVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<WarpVolume>(planetGO, ref sector, info);
 
             volume.TargetSolarSystem = info.targetStarSystem;
             volume.TargetSpawnID = info.spawnPointID;

--- a/NewHorizons/Builder/Volumes/ConditionTriggerVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ConditionTriggerVolumeBuilder.cs
@@ -8,7 +8,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static ConditionTriggerVolume Make(GameObject planetGO, Sector sector, ConditionTriggerVolumeInfo info)
         {
-            var volume = VolumeBuilder.Make<ConditionTriggerVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<ConditionTriggerVolume>(planetGO, ref sector, info);
 
             volume.Condition = info.condition;
             volume.Persistent = info.persistent;

--- a/NewHorizons/Builder/Volumes/CreditsVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/CreditsVolumeBuilder.cs
@@ -10,7 +10,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static LoadCreditsVolume Make(GameObject planetGO, Sector sector, LoadCreditsVolumeInfo info, IModBehaviour mod)
         {
-            var volume = VolumeBuilder.Make<LoadCreditsVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<LoadCreditsVolume>(planetGO, ref sector, info);
 
             volume.gameOver = info.gameOver;
             volume.deathType = info.deathType == null ? null : EnumUtils.Parse(info.deathType.ToString(), DeathType.Default);

--- a/NewHorizons/Builder/Volumes/DayNightAudioVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/DayNightAudioVolumeBuilder.cs
@@ -12,10 +12,10 @@ namespace NewHorizons.Builder.Volumes
     {
         public static NHDayNightAudioVolume Make(GameObject planetGO, Sector sector, DayNightAudioVolumeInfo info, IModBehaviour mod)
         {
-            var go = GeneralPropBuilder.MakeNew("DayNightAudioVolume", planetGO, sector, info);
+            var go = GeneralPropBuilder.MakeNew("DayNightAudioVolume", planetGO, ref sector, info);
             go.layer = Layer.AdvancedEffectVolume;
 
-            var audioVolume = PriorityVolumeBuilder.MakeExisting<NHDayNightAudioVolume>(go, planetGO, sector, info);
+            var audioVolume = PriorityVolumeBuilder.MakeExisting<NHDayNightAudioVolume>(go, planetGO, ref sector, info);
 
             audioVolume.sunName = info.sun;
             audioVolume.dayWindow = info.dayWindow;

--- a/NewHorizons/Builder/Volumes/FluidVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/FluidVolumeBuilder.cs
@@ -15,15 +15,15 @@ namespace NewHorizons.Builder.Volumes
             {
                 case FluidVolume.Type.PLASMA:
                 case FluidVolume.Type.WATER:
-                    var radialVolume = PriorityVolumeBuilder.Make<RadialFluidVolume>(planetGO, sector, info);
+                    var radialVolume = PriorityVolumeBuilder.Make<RadialFluidVolume>(planetGO, ref sector, info);
                     radialVolume._radius = info.radius;
                     volume = radialVolume;
                     break;
                 case FluidVolume.Type.CLOUD:
-                    volume = PriorityVolumeBuilder.Make<CloudLayerFluidVolume>(planetGO, sector, info);
+                    volume = PriorityVolumeBuilder.Make<CloudLayerFluidVolume>(planetGO, ref sector, info);
                     break;
                 default:
-                    var sphericalVolume = PriorityVolumeBuilder.Make<SphericalFluidVolume>(planetGO, sector, info);
+                    var sphericalVolume = PriorityVolumeBuilder.Make<SphericalFluidVolume>(planetGO, ref sector, info);
                     sphericalVolume.radius = info.radius;
                     volume = sphericalVolume;
                     break;

--- a/NewHorizons/Builder/Volumes/ForceVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ForceVolumeBuilder.cs
@@ -100,7 +100,7 @@ namespace NewHorizons.Builder.Volumes
 
         public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, ForceVolumeInfo info) where TVolume : ForceVolume
         {
-            var forceVolume = PriorityVolumeBuilder.Make<TVolume>(planetGO, sector, info);
+            var forceVolume = PriorityVolumeBuilder.Make<TVolume>(planetGO, ref sector, info);
 
             forceVolume._alignmentPriority = info.alignmentPriority;
             forceVolume._inheritable = info.inheritable;

--- a/NewHorizons/Builder/Volumes/HazardVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/HazardVolumeBuilder.cs
@@ -13,7 +13,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static HazardVolume Make(GameObject planetGO, Sector sector, OWRigidbody owrb, HazardVolumeInfo info, IModBehaviour mod)
         {
-            var go = GeneralPropBuilder.MakeNew("HazardVolume", planetGO, sector, info);
+            var go = GeneralPropBuilder.MakeNew("HazardVolume", planetGO, ref sector, info);
             
             var volume = MakeExisting(go, planetGO, sector, owrb, info);
 
@@ -27,15 +27,15 @@ namespace NewHorizons.Builder.Volumes
             HazardVolume hazardVolume = null;
             if (info.type == HazardVolumeInfo.HazardType.RIVERHEAT)
             {
-                hazardVolume = VolumeBuilder.MakeExisting<RiverHeatHazardVolume>(go, planetGO, sector, info);
+                hazardVolume = VolumeBuilder.MakeExisting<RiverHeatHazardVolume>(go, planetGO, ref sector, info);
             }
             else if (info.type == HazardVolumeInfo.HazardType.HEAT)
             {
-                hazardVolume = VolumeBuilder.MakeExisting<HeatHazardVolume>(go, planetGO, sector, info);
+                hazardVolume = VolumeBuilder.MakeExisting<HeatHazardVolume>(go, planetGO, ref sector, info);
             }
             else if (info.type == HazardVolumeInfo.HazardType.DARKMATTER)
             {
-                hazardVolume = VolumeBuilder.MakeExisting<DarkMatterVolume>(go, planetGO, sector, info);
+                hazardVolume = VolumeBuilder.MakeExisting<DarkMatterVolume>(go, planetGO, ref sector, info);
                 var visorFrostEffectVolume = go.AddComponent<VisorFrostEffectVolume>();
                 visorFrostEffectVolume._frostRate = 0.5f;
                 visorFrostEffectVolume._maxFrost = 0.91f;
@@ -63,7 +63,7 @@ namespace NewHorizons.Builder.Volumes
             }
             else if (info.type == HazardVolumeInfo.HazardType.ELECTRICITY)
             {
-                var electricityVolume = VolumeBuilder.MakeExisting<ElectricityVolume>(go, planetGO, sector, info);
+                var electricityVolume = VolumeBuilder.MakeExisting<ElectricityVolume>(go, planetGO, ref sector, info);
                 electricityVolume._shockAudioPool = new OWAudioSource[0];
                 hazardVolume = electricityVolume;
             }

--- a/NewHorizons/Builder/Volumes/InteractionVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/InteractionVolumeBuilder.cs
@@ -20,7 +20,7 @@ namespace NewHorizons.Builder.Volumes
                 info.shape.useShape = false;
             }
 
-            var receiver = VolumeBuilder.Make<InteractReceiver>(planetGO, sector, info);
+            var receiver = VolumeBuilder.Make<InteractReceiver>(planetGO, ref sector, info);
             receiver.gameObject.layer = Layer.Interactible;
 
             receiver._interactRange = info.range;

--- a/NewHorizons/Builder/Volumes/NotificationVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/NotificationVolumeBuilder.cs
@@ -11,7 +11,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static NHNotificationVolume Make(GameObject planetGO, Sector sector, NotificationVolumeInfo info, IModBehaviour mod)
         {
-            var notificationVolume = VolumeBuilder.Make<NHNotificationVolume>(planetGO, sector, info);
+            var notificationVolume = VolumeBuilder.Make<NHNotificationVolume>(planetGO, ref sector, info);
 
             // Preserving name for backwards compatibility
             notificationVolume.gameObject.name = string.IsNullOrEmpty(info.rename) ? "NotificationVolume" : info.rename;

--- a/NewHorizons/Builder/Volumes/OxygenVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/OxygenVolumeBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static OxygenVolume Make(GameObject planetGO, Sector sector, OxygenVolumeInfo info)
         {
-            var volume = VolumeBuilder.Make<OxygenVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<OxygenVolume>(planetGO, ref sector, info);
 
             volume._treeVolume = info.treeVolume;
             volume._playRefillAudio = info.playRefillAudio;

--- a/NewHorizons/Builder/Volumes/PriorityVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/PriorityVolumeBuilder.cs
@@ -1,13 +1,24 @@
 using NewHorizons.External.Modules.Volumes.VolumeInfos;
+using System;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Volumes
 {
     public static class PriorityVolumeBuilder
     {
+        #region obsolete
+        // Changed to ref sector
+        [Obsolete]
         public static TVolume MakeExisting<TVolume>(GameObject go, GameObject planetGO, Sector sector, PriorityVolumeInfo info) where TVolume : PriorityVolume
+            => MakeExisting<TVolume>(go, planetGO, ref sector, info);
+        [Obsolete]
+        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, PriorityVolumeInfo info) where TVolume : PriorityVolume
+            => Make<TVolume>(planetGO, ref sector, info);
+        #endregion
+
+        public static TVolume MakeExisting<TVolume>(GameObject go, GameObject planetGO, ref Sector sector, PriorityVolumeInfo info) where TVolume : PriorityVolume
         {
-            var volume = VolumeBuilder.MakeExisting<TVolume>(go, planetGO, sector, info);
+            var volume = VolumeBuilder.MakeExisting<TVolume>(go, planetGO, ref sector, info);
 
             volume._layer = info.layer;
             volume.SetPriority(info.priority);
@@ -16,9 +27,9 @@ namespace NewHorizons.Builder.Volumes
         }
 
 
-        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, PriorityVolumeInfo info) where TVolume : PriorityVolume
+        public static TVolume Make<TVolume>(GameObject planetGO, ref Sector sector, PriorityVolumeInfo info) where TVolume : PriorityVolume
         {
-            var volume = VolumeBuilder.Make<TVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<TVolume>(planetGO, ref sector, info);
 
             volume._layer = info.layer;
             volume.SetPriority(info.priority);

--- a/NewHorizons/Builder/Volumes/RepairVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/RepairVolumeBuilder.cs
@@ -17,7 +17,7 @@ namespace NewHorizons.Builder.Volumes
         {
             // Repair receivers aren't technically volumes (no OWTriggerVolume) so we don't use the VolumeBuilder
 
-            var go = GeneralPropBuilder.MakeNew("RepairVolume", planetGO, sector, info);
+            var go = GeneralPropBuilder.MakeNew("RepairVolume", planetGO, ref sector, info);
 
             if (info.shape != null)
             {

--- a/NewHorizons/Builder/Volumes/Rulesets/PlayerImpactRulesetBuilder.cs
+++ b/NewHorizons/Builder/Volumes/Rulesets/PlayerImpactRulesetBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes.Rulesets
     {
         public static PlayerImpactRuleset Make(GameObject planetGO, Sector sector, RulesetModule.PlayerImpactRulesetInfo info)
         {
-            var volume = VolumeBuilder.Make<PlayerImpactRuleset>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<PlayerImpactRuleset>(planetGO, ref sector, info);
 
             volume.minImpactSpeed = info.minImpactSpeed;
             volume.maxImpactSpeed = info.maxImpactSpeed;

--- a/NewHorizons/Builder/Volumes/Rulesets/ProbeRulesetBuilder.cs
+++ b/NewHorizons/Builder/Volumes/Rulesets/ProbeRulesetBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes.Rulesets
     {
         public static ProbeRuleset Make(GameObject planetGO, Sector sector, RulesetModule.ProbeRulesetInfo info)
         {
-            var volume = VolumeBuilder.Make<ProbeRuleset>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<ProbeRuleset>(planetGO, ref sector, info);
 
             volume._overrideProbeSpeed = info.overrideProbeSpeed;
             volume._probeSpeedOverride = info.probeSpeed;

--- a/NewHorizons/Builder/Volumes/Rulesets/ThrustRulesetBuilder.cs
+++ b/NewHorizons/Builder/Volumes/Rulesets/ThrustRulesetBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes.Rulesets
     {
         public static ThrustRuleset Make(GameObject planetGO, Sector sector, RulesetModule.ThrustRulesetInfo info)
         {
-            var volume = VolumeBuilder.Make<ThrustRuleset>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<ThrustRuleset>(planetGO, ref sector, info);
 
             volume._thrustLimit = info.thrustLimit;
             volume._nerfJetpackBooster = info.nerfJetpackBooster;

--- a/NewHorizons/Builder/Volumes/SpeedLimiterVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/SpeedLimiterVolumeBuilder.cs
@@ -8,7 +8,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static SpeedLimiterVolume Make(GameObject planetGO, Sector sector, SpeedLimiterVolumeInfo info)
         {
-            var volume = VolumeBuilder.Make<SpeedLimiterVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<SpeedLimiterVolume>(planetGO, ref sector, info);
 
             volume.maxSpeed = info.maxSpeed;
             volume.stoppingDistance = info.stoppingDistance;

--- a/NewHorizons/Builder/Volumes/SpeedTrapVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/SpeedTrapVolumeBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static SpeedTrapVolume Make(GameObject planetGO, Sector sector, SpeedTrapVolumeInfo info)
         {
-            var volume = VolumeBuilder.Make<SpeedTrapVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<SpeedTrapVolume>(planetGO, ref sector, info);
 
             volume._speedLimit = info.speedLimit;
             volume._acceleration = info.acceleration;

--- a/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VanishVolumeBuilder.cs
@@ -18,7 +18,7 @@ namespace NewHorizons.Builder.Volumes
             info.shape ??= new();
             info.shape.useShape = false;
 
-            var volume = VolumeBuilder.Make<TVolume>(planetGO, sector, info);
+            var volume = VolumeBuilder.Make<TVolume>(planetGO, ref sector, info);
 
             var collider = volume.gameObject.GetComponent<Collider>();
             volume._collider = collider;

--- a/NewHorizons/Builder/Volumes/VisorEffects/VisorFrostEffectVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VisorEffects/VisorFrostEffectVolumeBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes.VisorEffects
     {
         public static VisorFrostEffectVolume Make(GameObject planetGO, Sector sector, VisorEffectModule.FrostEffectVolumeInfo info)
         {
-            var volume = PriorityVolumeBuilder.Make<VisorFrostEffectVolume>(planetGO, sector, info);
+            var volume = PriorityVolumeBuilder.Make<VisorFrostEffectVolume>(planetGO, ref sector, info);
 
             volume._frostRate = info.frostRate;
             volume._maxFrost = info.maxFrost;

--- a/NewHorizons/Builder/Volumes/VisorEffects/VisorRainEffectVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VisorEffects/VisorRainEffectVolumeBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes.VisorEffects
     {
         public static VisorRainEffectVolume Make(GameObject planetGO, Sector sector, VisorEffectModule.RainEffectVolumeInfo info)
         {
-            var volume = PriorityVolumeBuilder.Make<VisorRainEffectVolume>(planetGO, sector, info);
+            var volume = PriorityVolumeBuilder.Make<VisorRainEffectVolume>(planetGO, ref sector, info);
 
             volume._rainDirection = VisorRainEffectVolume.RainDirection.Radial;
             volume._dropletRate = info.dropletRate;

--- a/NewHorizons/Builder/Volumes/VolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/VolumeBuilder.cs
@@ -2,13 +2,27 @@ using NewHorizons.Builder.Props;
 using NewHorizons.External.Modules.Volumes.VolumeInfos;
 using NewHorizons.Utility.OuterWilds;
 using NewHorizons.Utility.OWML;
+using System;
 using UnityEngine;
 
 namespace NewHorizons.Builder.Volumes
 {
     public static class VolumeBuilder
     {
+        #region obsolete
+        // Changed to ref sector
+        [Obsolete]
         public static TVolume MakeExisting<TVolume>(GameObject go, GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
+            => MakeExisting<TVolume>(go, planetGO, ref sector, info);
+        [Obsolete]
+        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
+            => Make<TVolume>(planetGO, ref sector, info);
+        // Intentionally not marking this one Obsolete because it's only used by VolumesBuildManager and would clutter that code
+        public static TVolume MakeAndEnable<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
+            => MakeAndEnable<TVolume>(planetGO, ref sector, info);
+        #endregion
+
+        public static TVolume MakeExisting<TVolume>(GameObject go, GameObject planetGO, ref Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
         {
             // Backwards compat for the two possible radii settings
             // Both radii default to 1
@@ -45,15 +59,15 @@ namespace NewHorizons.Builder.Volumes
             return volume;
         }
 
-        public static TVolume Make<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour // Could be BaseVolume but I need to create vanilla volumes too.
+        public static TVolume Make<TVolume>(GameObject planetGO, ref Sector sector, VolumeInfo info) where TVolume : MonoBehaviour // Could be BaseVolume but I need to create vanilla volumes too.
         {
-            var go = GeneralPropBuilder.MakeNew(typeof(TVolume).Name, planetGO, sector, info);
-            return MakeExisting<TVolume>(go, planetGO, sector, info);
+            var go = GeneralPropBuilder.MakeNew(typeof(TVolume).Name, planetGO, ref sector, info);
+            return MakeExisting<TVolume>(go, planetGO, ref sector, info);
         }
 
-        public static TVolume MakeAndEnable<TVolume>(GameObject planetGO, Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
+        public static TVolume MakeAndEnable<TVolume>(GameObject planetGO, ref Sector sector, VolumeInfo info) where TVolume : MonoBehaviour
         {
-            var volume = Make<TVolume>(planetGO, sector, info);
+            var volume = Make<TVolume>(planetGO, ref sector, info);
             volume.gameObject.SetActive(true);
             return volume;
         }

--- a/NewHorizons/Builder/Volumes/ZeroGVolumeBuilder.cs
+++ b/NewHorizons/Builder/Volumes/ZeroGVolumeBuilder.cs
@@ -7,7 +7,7 @@ namespace NewHorizons.Builder.Volumes
     {
         public static ZeroGVolume Make(GameObject planetGO, Sector sector, PriorityVolumeInfo info)
         {
-            var volume = PriorityVolumeBuilder.Make<ZeroGVolume>(planetGO, sector, info);
+            var volume = PriorityVolumeBuilder.Make<ZeroGVolume>(planetGO, ref sector, info);
 
             volume._inheritable = true;
 

--- a/NewHorizons/External/Modules/GeneralPropInfo.cs
+++ b/NewHorizons/External/Modules/GeneralPropInfo.cs
@@ -8,9 +8,14 @@ namespace NewHorizons.External.Modules
     public abstract class BasePropInfo
     {
         /// <summary>
-        /// The relative path from the planet to the parent of this object. Optional (will default to the root sector).
+        /// The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector).
         /// </summary>
         public string parentPath;
+
+        /// <summary>
+        /// The relative path from the planet to the sector that this object will be linked to. The special value "auto" will use the most specific sector in the parent path. Optional (will default to the planet's root sector).
+        /// </summary>
+        public string sectorPath;
 
         /// <summary>
         /// An optional rename of this object

--- a/NewHorizons/Handlers/HeldItemHandler.cs
+++ b/NewHorizons/Handlers/HeldItemHandler.cs
@@ -68,7 +68,8 @@ public static class HeldItemHandler
 
         var tempParent = new GameObject();
         tempParent.transform.position = new Vector3(100000, 0, 0);
-        var newObject = DetailBuilder.Make(tempParent, tempParent.AddComponent<Sector>(), null, go, new DetailInfo() { keepLoaded = true });
+        var sector = tempParent.AddComponent<Sector>();
+        var newObject = DetailBuilder.Make(tempParent, ref sector, null, go, new DetailInfo() { keepLoaded = true });
         newObject.SetActive(false);
         newObject.transform.parent = null;
         newObject.name = go.name;

--- a/NewHorizons/Handlers/TitleSceneHandler.cs
+++ b/NewHorizons/Handlers/TitleSceneHandler.cs
@@ -184,7 +184,8 @@ namespace NewHorizons.Handlers
                 {
                     foreach (var simplifiedDetail in config.Background.details)
                     {
-                        DetailBuilder.Make(background, background.GetComponentInParent<Sector>(), mod, new DetailInfo(simplifiedDetail));
+                        var sector = background.GetComponentInParent<Sector>();
+                        DetailBuilder.Make(background, ref sector, mod, new DetailInfo(simplifiedDetail));
                     }
                 }
 
@@ -203,7 +204,8 @@ namespace NewHorizons.Handlers
                 {
                     foreach (var simplifiedDetail in config.MenuPlanet.details)
                     {
-                        DetailBuilder.Make(menuPlanet, menuPlanet.GetComponentInParent<Sector>(), mod, new DetailInfo(simplifiedDetail));
+                        var sector = menuPlanet.GetComponentInParent<Sector>();
+                        DetailBuilder.Make(menuPlanet, ref sector, mod, new DetailInfo(simplifiedDetail));
                     }
                 }
 

--- a/NewHorizons/Handlers/VesselWarpHandler.cs
+++ b/NewHorizons/Handlers/VesselWarpHandler.cs
@@ -150,12 +150,14 @@ namespace NewHorizons.Handlers
             if (VesselPrefab == null) return null;
 
             NHLogger.LogVerbose("Creating Vessel");
-            var vesselObject = GeneralPropBuilder.MakeFromPrefab(VesselPrefab, VesselPrefab.name, null, null, system.Config.Vessel?.vesselSpawn);
+            Sector sector = null;
+            var vesselObject = GeneralPropBuilder.MakeFromPrefab(VesselPrefab, VesselPrefab.name, null, ref sector, system.Config.Vessel?.vesselSpawn);
             VesselObject = vesselObject;
+            sector = vesselObject.GetComponentInChildren<Sector>(true);
 
             var vesselAO = vesselObject.AddComponent<EyeAstroObject>();
             vesselAO._owRigidbody = vesselObject.GetComponent<OWRigidbody>();
-            vesselAO._rootSector = vesselObject.GetComponentInChildren<Sector>(true);
+            vesselAO._rootSector = sector;
             vesselAO._customName = "Vessel";
             vesselAO._name = AstroObject.Name.CustomString;
             vesselAO._type = AstroObject.Type.SpaceStation;
@@ -248,7 +250,8 @@ namespace NewHorizons.Handlers
             var attachWarpExitToVessel = system.Config.Vessel?.warpExit?.attachToVessel ?? false;
             var warpExitParent = vesselWarpController._targetWarpPlatform.transform.parent;
 
-            var warpExit = GeneralPropBuilder.MakeFromExisting(vesselWarpController._targetWarpPlatform.gameObject, planetGO, null, system.Config.Vessel?.warpExit, defaultParent: attachWarpExitToVessel ? warpExitParent : null);
+            Sector warpExitSector = null;
+            var warpExit = GeneralPropBuilder.MakeFromExisting(vesselWarpController._targetWarpPlatform.gameObject, planetGO, ref warpExitSector, system.Config.Vessel?.warpExit, defaultParent: attachWarpExitToVessel ? warpExitParent : null);
             if (attachWarpExitToVessel)
             {
                 warpExit.transform.parent = warpExitParent;

--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -209,7 +209,7 @@ namespace NewHorizons
                 scale = scale,
                 alignRadial = alignRadial
             };
-            return DetailBuilder.Make(planet, sector, mod, prefab, detailInfo);
+            return DetailBuilder.Make(planet, ref sector, mod, prefab, detailInfo);
         }
 
         public AudioSignal SpawnSignal(IModBehaviour mod, GameObject root, string audio, string name, string frequency,

--- a/NewHorizons/Schemas/body_schema.json
+++ b/NewHorizons/Schemas/body_schema.json
@@ -802,7 +802,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1046,7 +1050,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1215,7 +1223,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1313,7 +1325,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1376,7 +1392,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1450,7 +1470,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1480,7 +1504,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1517,7 +1545,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1674,7 +1706,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -1790,7 +1826,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2448,7 +2488,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2520,7 +2564,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2561,7 +2609,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2640,7 +2692,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2809,7 +2865,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2856,7 +2916,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -2960,7 +3024,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3167,7 +3235,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3335,7 +3407,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3405,7 +3481,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3529,7 +3609,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3608,7 +3692,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3654,7 +3742,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3691,7 +3783,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3736,7 +3832,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3773,7 +3873,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3826,7 +3930,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3904,7 +4012,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3951,7 +4063,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -3995,7 +4111,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4134,7 +4254,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4177,7 +4301,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4246,7 +4374,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4286,7 +4418,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4323,7 +4459,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4364,7 +4504,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4421,7 +4565,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4470,7 +4618,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4524,7 +4676,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4557,7 +4713,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -4651,7 +4811,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5018,7 +5182,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5075,7 +5243,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5607,7 +5779,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5803,7 +5979,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5883,7 +6063,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -5968,7 +6152,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6066,7 +6254,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6200,7 +6392,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6278,7 +6474,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6365,7 +6565,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6471,7 +6675,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6549,7 +6757,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6611,7 +6823,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6675,7 +6891,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6754,7 +6974,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6807,7 +7031,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6893,7 +7121,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -6965,7 +7197,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7042,7 +7278,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7180,7 +7420,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7235,7 +7479,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7300,7 +7548,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7359,7 +7611,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7414,7 +7670,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7507,7 +7767,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7576,7 +7840,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7631,7 +7899,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7686,7 +7958,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -7738,7 +8014,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",

--- a/NewHorizons/Schemas/star_system_schema.json
+++ b/NewHorizons/Schemas/star_system_schema.json
@@ -311,7 +311,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",
@@ -366,7 +370,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",

--- a/NewHorizons/Schemas/title_screen_schema.json
+++ b/NewHorizons/Schemas/title_screen_schema.json
@@ -196,7 +196,11 @@
         },
         "parentPath": {
           "type": "string",
-          "description": "The relative path from the planet to the parent of this object. Optional (will default to the root sector)."
+          "description": "The relative path from the planet to the parent of this object. Optional (will default to the planet's root sector)."
+        },
+        "sectorPath": {
+          "type": "string",
+          "description": "The relative path from the planet to the sector that this object will be linked to. The special value \"auto\" will use the most specific sector in the parent path. Optional (will default to the planet's root sector)."
         },
         "rename": {
           "type": "string",


### PR DESCRIPTION
## Minor features

- Added `sectorPath` to most props to allow specifying a sector other than the planet's root sector for the purposes of culling and other sector behavior. The special value `"auto"` finds the first sector in the prop's parent hierarchy.