### PR TITLE
GetPlanet bugfix

### DIFF
--- a/NewHorizons/NewHorizonsApi.cs
+++ b/NewHorizons/NewHorizonsApi.cs
@@ -83,7 +83,7 @@ namespace NewHorizons
 
         public GameObject GetPlanet(string name)
         {
-            return Main.BodyDict.Values.SelectMany(x => x)?.ToList()?.FirstOrDefault(x => x.Config.name == name)?.Object;
+            return Main.BodyDict[Main.Instance.CurrentStarSystem].FirstOrDefault(x => x.Config.name == name)?.Object;
         }
 
         public string GetCurrentStarSystem() => Main.Instance.CurrentStarSystem;


### PR DESCRIPTION
## Bug fixes

- Make GetPlanet only check planets in the current system. This prevents it from pulling the wrong config if a planet in another system has the same name.
